### PR TITLE
fix: harden ByExpression status matching

### DIFF
--- a/pkg/jq/validation.go
+++ b/pkg/jq/validation.go
@@ -223,6 +223,8 @@ func checkASTNode(v reflect.Value) error {
 			return ErrDelFunc
 		case "range", "paths", "recurse", "walk", "repeat":
 			return fmt.Errorf("function '%s' may produce excessive output and is not allowed", n.Name)
+		case "until", "while":
+			return fmt.Errorf("function '%s' may loop unboundedly and is not allowed", n.Name)
 		}
 	}
 	return nil

--- a/pkg/jq/validation_test.go
+++ b/pkg/jq/validation_test.go
@@ -138,6 +138,8 @@ var _ = Describe("JQ Validation", func() {
 			Entry("should reject paths function", "paths", "function 'paths'"),
 			Entry("should reject range function", "range(1000000)", "function 'range'"),
 			Entry("should reject repeat function", "repeat(.)", "function 'repeat'"),
+			Entry("should reject until function", `"x" | until(length > 1000000; . + .)`, "function 'until'"),
+			Entry("should reject while function", `"x" | while(length < 1000000; . + .)`, "function 'while'"),
 
 			// Recursive descent operator
 			Entry("should reject recursive descent operator", ".. | .name", "recursive descent operator"),

--- a/pkg/resource/accessor.go
+++ b/pkg/resource/accessor.go
@@ -674,8 +674,7 @@ func match(ctx context.Context, jqRunner execution.Runner, phase *string, condit
 }
 
 func matchByExpression(ctx context.Context, jqRunner execution.Runner, matcher v1alpha1.StatusMatcher) (bool, error) {
-	// Construct a jq expression that compares the result with the expected value
-	comparisonExpr := fmt.Sprintf("(%s) | tostring == \"%s\"", matcher.ByExpression.Expression, matcher.ByExpression.ExpectedResult)
+	comparisonExpr := fmt.Sprintf("(%s) | tostring", matcher.ByExpression.Expression)
 
 	results, err := jqRunner.Evaluate(ctx, comparisonExpr)
 	if err != nil {
@@ -691,13 +690,12 @@ func matchByExpression(ctx context.Context, jqRunner execution.Runner, matcher v
 		return false, nil
 	}
 
-	// The result must be a boolean from the jq comparison expression
-	matched, ok := result.(bool)
+	actual, ok := result.(string)
 	if !ok {
-		return false, fmt.Errorf("expression comparison did not return a boolean, got %T", result)
+		return false, fmt.Errorf("expression result did not convert to a string, got %T", result)
 	}
 
-	return matched, nil
+	return actual == matcher.ByExpression.ExpectedResult, nil
 }
 
 func checkCondition(conditionsMap map[string]Condition, expectedCond v1alpha1.ExpectedCondition) (Condition, bool) {

--- a/pkg/resource/accessor_test.go
+++ b/pkg/resource/accessor_test.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1355,6 +1358,65 @@ var _ = Describe("Accessor", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to match status"))
 				Expect(result).To(BeNil())
+			})
+
+			It("should treat ExpectedResult as a literal value, not evaluate it", func() {
+				reactorObject := types.NewReactorObject()
+				reactorObject.Status.Phase = "running"
+				reactorKarta := types.ReactorKarta()
+				reactorKarta.Spec.StructureDefinition.RootComponent.StatusDefinition.StatusMappings = v1alpha1.StatusMappings{
+					Failed: []v1alpha1.StatusMatcher{
+						{
+							ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression: `.status.phase`,
+								ExpectedResult: `failed" or . == . #`,
+							},
+						},
+					},
+				}
+				accessor, reactorComp := accessorForObject(reactorKarta, reactorObject, "reactor")
+
+				result, err := accessor.ExtractStatus(ctx, reactorComp.definition)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.MatchedStatuses).To(ConsistOf(v1alpha1.UndefinedStatus))
+			})
+
+			It("should not evaluate the contents of ExpectedResult", func() {
+				const doublingTargetBytes = 32 * 1024 * 1024
+				const allocCeilingBytes = 8 * 1024 * 1024
+
+				prevLimit := debug.SetMemoryLimit(256 * 1024 * 1024)
+				defer debug.SetMemoryLimit(prevLimit)
+
+				reactorObject := types.NewReactorObject()
+				reactorObject.Status.Phase = "running"
+				reactorKarta := types.ReactorKarta()
+				reactorKarta.Spec.StructureDefinition.RootComponent.StatusDefinition.StatusMappings = v1alpha1.StatusMappings{
+					Running: []v1alpha1.StatusMatcher{
+						{
+							ByExpression: &v1alpha1.ExpressionMatcher{
+								Expression: `.`,
+								ExpectedResult: fmt.Sprintf(`\("x" | until(length > %d; . + .))`, doublingTargetBytes),
+							},
+						},
+					},
+				}
+				accessor, reactorComp := accessorForObject(reactorKarta, reactorObject, "reactor")
+
+				var before, after runtime.MemStats
+				runtime.GC()
+				runtime.ReadMemStats(&before)
+
+				_, err := accessor.ExtractStatus(ctx, reactorComp.definition)
+
+				runtime.ReadMemStats(&after)
+				allocated := after.TotalAlloc - before.TotalAlloc
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(allocated).To(BeNumerically("<", uint64(allocCeilingBytes)),
+					"ExpectedResult drove %d MiB of allocation", allocated/(1024*1024))
 			})
 		})
 


### PR DESCRIPTION
## What does this PR do?

Harden ByExpression status matching.

`ExpectedResult` is a user-provided value that was being built into the evaluated
JQ program. This changes `matchByExpression` to evaluate only the `Expression` and
compare its string result to `ExpectedResult` in Go, so the value is treated as
data rather than program text. Behaviour is unchanged for existing definitions:
the expression output is still string-compared to `ExpectedResult`.

Also aligns the JQ deny list: `until` and `while` are now rejected alongside the
existing unbounded constructs (`range`, `recurse`, `walk`, `repeat`, `paths`).
`limit` stays allowed since it bounds output.

### Compatibility

- Every `ExpectedResult` in the catalog is `"true"`; behaviour is identical.
- No catalog `Expression` uses `until` / `while`.
- Full test suite, lint, and CLI tests pass.

### Note

- `ExpectedResult` is now compared literally, so JQ escape sequences inside it are
  no longer interpreted. No shipped definition relies on that.

## Related issue(s)

Tracked internally.

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [ ] Documentation updated (not applicable)
- [x] Tests pass (`make lint`, `go test ./...`, `make cli-test` green)
- [x] No proprietary or internal information included
