### PR TITLE
fix(catalog): read the terminal conditions of Job and the working state of JobSet

### DIFF
--- a/docs/catalog/batch-job-v1.yaml
+++ b/docs/catalog/batch-job-v1.yaml
@@ -36,9 +36,15 @@ spec:
             - byConditions:
                 - type: Complete
                   status: "True"
+            - byConditions:
+                - type: SuccessCriteriaMet
+                  status: "True"
           failed:
             - byConditions:
                 - type: Failed
+                  status: "True"
+            - byConditions:
+                - type: FailureTarget
                   status: "True"
           degraded:
             - byExpression:

--- a/docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
+++ b/docs/catalog/jobset-x-k8s-io-jobset-v1alpha2.yaml
@@ -22,11 +22,11 @@ spec:
         statusMappings:
           initializing:
             - byExpression:
-                expression: (.status.replicatedJobsStatus // []) | any(.active > 0 and (.ready // 0) == 0) and all(.failed == 0)
+                expression: ((.status.replicatedJobsStatus // []) | length) > 0 and ((.status.replicatedJobsStatus // []) | all((.active // 0) == 0 and (.ready // 0) == 0)) and (([.status.conditions[]? | select((.type == "Completed" or .type == "Failed" or .type == "Suspended") and .status == "True")] | length) == 0)
                 expectedResult: "true"
           running:
             - byExpression:
-                expression: (.status.replicatedJobsStatus // []) | any(.ready > 0 and .active > 0) and all(.failed == 0)
+                expression: (.status.replicatedJobsStatus // []) | any(.active > 0 or .ready > 0) and all((.failed // 0) == 0)
                 expectedResult: "true"
           completed:
             - byConditions:

--- a/pkg/catalog/kartas/batch_job.go
+++ b/pkg/catalog/kartas/batch_job.go
@@ -43,8 +43,14 @@ func BatchJob() *v1alpha1.Karta {
 								Expression:     "(.status.active // 0) > 0 and (.status.ready // 0) > 0",
 								ExpectedResult: "true",
 							}}},
-							Completed: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Complete", Status: ptr.To("True")}}}},
-							Failed:    []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Failed", Status: ptr.To("True")}}}},
+							Completed: []v1alpha1.StatusMatcher{
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Complete", Status: ptr.To("True")}}},
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "SuccessCriteriaMet", Status: ptr.To("True")}}},
+							},
+							Failed: []v1alpha1.StatusMatcher{
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Failed", Status: ptr.To("True")}}},
+								{ByConditions: []v1alpha1.ExpectedCondition{{Type: "FailureTarget", Status: ptr.To("True")}}},
+							},
 							Degraded: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
 								Expression:     ".spec.parallelism > 1 and (.status.ready // 0) < .spec.parallelism and ((.status.succeeded // 0) > 0 or (.status.failed // 0) > 0)",
 								ExpectedResult: "true",

--- a/pkg/catalog/kartas/jobset.go
+++ b/pkg/catalog/kartas/jobset.go
@@ -35,15 +35,18 @@ func Jobset() *v1alpha1.Karta {
 						},
 						StatusMappings: v1alpha1.StatusMappings{
 							Initializing: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
-								// Some replicatedJobs are active but none are ready yet.
-								// Guard against a null replicatedJobsStatus before the JobSet
-								// controller initializes status.
-								Expression:     "(.status.replicatedJobsStatus // []) | any(.active > 0 and (.ready // 0) == 0) and all(.failed == 0)",
+								// In progress with no working pods: status exists, no replicatedJob has
+								// active or ready pods, and no terminal or suspended condition is set.
+								// Covers a just-created JobSet (all counts zero) and the window after a
+								// job succeeds but before the JobSet-level Completed condition is set.
+								Expression:     "((.status.replicatedJobsStatus // []) | length) > 0 and ((.status.replicatedJobsStatus // []) | all((.active // 0) == 0 and (.ready // 0) == 0)) and (([.status.conditions[]? | select((.type == \"Completed\" or .type == \"Failed\" or .type == \"Suspended\") and .status == \"True\")] | length) == 0)",
 								ExpectedResult: "true",
 							}}},
 							Running: []v1alpha1.StatusMatcher{{ByExpression: &v1alpha1.ExpressionMatcher{
-								// Total ready across all replicatedJobs equals total expected replicas.
-								Expression:     "(.status.replicatedJobsStatus // []) | any(.ready > 0 and .active > 0) and all(.failed == 0)",
+								// Working: at least one replicatedJob has active or ready pods and none
+								// have failed. Reading either count (not both) keeps the state stable
+								// while the controller briefly flaps ready to 0 mid-run.
+								Expression:     "(.status.replicatedJobsStatus // []) | any(.active > 0 or .ready > 0) and all((.failed // 0) == 0)",
 								ExpectedResult: "true",
 							}}},
 							Completed: []v1alpha1.StatusMatcher{{ByConditions: []v1alpha1.ExpectedCondition{{Type: "Completed", Status: ptr.To("True")}}}},


### PR DESCRIPTION
Fixes the two catalog definitions that misread states their operators actually write, found by replaying every recorded e2e fixture frame through the real library.

- batch Job: a succeeding Job writes `SuccessCriteriaMet=True` before `Complete`, a failing one writes `FailureTarget=True` before `Failed`. The Completed and Failed mappings each gain a second condition matcher.
- JobSet: the controller briefly flaps `ready` to 0 mid-run while `active` stays set, and the old expressions read that as Initializing on a running workload. Running now means a replicatedJob has active or ready pods; Initializing covers in-progress with no working pods and no terminal condition.

Verified by replaying all seven recorded Job and JobSet fixtures frame by frame through the updated definitions: every frame reads the recorded state. `make check` passes.

Scope note: earlier revisions of this branch also added matchers for transition states that operators report only through the absence of fields (missing conditions, empty phases). Those are dropped on purpose, per review: positive signal rules stay in the catalog, transient absence windows are handled on the test side by the replay suite in a follow-up PR.

Ref #196.
