### PR TITLE
feat(cli): render the describe view

### DIFF
--- a/cli/pkg/generator/describe.go
+++ b/cli/pkg/generator/describe.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/run-ai/karta/cli/pkg/workload"
+)
+
+// ShowAllPods is the --pod-limit default: a hidden pod is the one a reader most
+// needs to see.
+const ShowAllPods = -1
+
+// fileModeNote marks output built from a manifest that never reached a cluster,
+// so an empty status section reads as "not applicable" and not as "healthy".
+const fileModeNote = "(file mode: no live status)"
+
+// DescribeOptions controls how one workload is rendered.
+type DescribeOptions struct {
+	// Output selects the format. The zero value renders the default table, so
+	// DescribeOptions{} is usable as-is.
+	Output Output
+	// PodLimit caps the pod rows per component. Negative shows every pod.
+	PodLimit int
+}
+
+// RenderWorkload writes one workload to out. The machine formats emit the view
+// itself, so what a human reads and what an agent parses cannot drift.
+func RenderWorkload(out io.Writer, view *workload.DescribeView, opts DescribeOptions) error {
+	format := opts.Output
+	if format == "" {
+		format = OutputTable
+	}
+
+	limit := opts.PodLimit
+	if opts.PodLimit == 0 {
+		// Zero pod rows hides the whole point of the command; treat the unset
+		// int as the default rather than as a request for nothing.
+		limit = ShowAllPods
+	}
+
+	return RenderOne(out, format, view, func(w io.Writer) error {
+		return workloadText(w, view, limit)
+	})
+}
+
+func workloadText(out io.Writer, view *workload.DescribeView, limit int) error {
+	if err := writeHeader(out, view); err != nil {
+		return err
+	}
+	if err := writeTree(out, view, limit); err != nil {
+		return err
+	}
+	if err := writeStatus(out, view); err != nil {
+		return err
+	}
+	return writeResources(out, view)
+}
+
+func writeHeader(out io.Writer, view *workload.DescribeView) error {
+	fields := []string{
+		fmt.Sprintf("%s/%s", view.Kind, view.Name),
+		"namespace: " + orNone(view.Namespace),
+		fmt.Sprintf("definition: %s (%s)", view.Definition, view.Origin),
+	}
+	if !view.FileMode {
+		fields = append(fields, "age: "+age(time.Now(), view.CreatedAt))
+	}
+
+	if _, err := fmt.Fprintln(out, strings.Join(fields, "   ")); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	if view.FileMode {
+		if _, err := fmt.Fprintln(out, fileModeNote); err != nil {
+			return fmt.Errorf("write header: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeTree renders the component hierarchy, one row per component and one per
+// pod, through a tab writer so every column lines up across both row kinds.
+func writeTree(out io.Writer, view *workload.DescribeView, limit int) error {
+	if len(view.Components) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return fmt.Errorf("write tree: %w", err)
+	}
+
+	writer := printers.GetNewTabWriter(out)
+	writeComponents(writer, view.Components, "", limit)
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write tree: %w", err)
+	}
+	return nil
+}
+
+func writeComponents(out io.Writer, components []workload.ComponentView, prefix string, limit int) {
+	for i, component := range components {
+		last := i == len(components)-1
+		fmt.Fprintln(out, strings.Join([]string{
+			prefix + branch(last) + component.Name,
+			readiness(component.Replicas),
+			resourceCell(component.Resources),
+			strings.Join(component.Nodes, ","),
+		}, "\t"))
+
+		childPrefix := prefix + indent(last)
+		writePods(out, component.Pods, childPrefix, limit)
+		writeComponents(out, component.Children, childPrefix, limit)
+	}
+}
+
+func writePods(out io.Writer, pods []workload.PodView, prefix string, limit int) {
+	shown, hidden, unhealthy := limitPods(pods, limit)
+
+	for i, pod := range shown {
+		// The truncation line is the last row under this component, so a shown
+		// pod is only "last" when nothing follows it.
+		last := i == len(shown)-1 && hidden == 0
+		fmt.Fprintln(out, strings.Join([]string{
+			prefix + branch(last) + pod.Name,
+			podStatus(pod),
+			resourceCell(pod.Resources),
+			orNone(deref(pod.Node)),
+		}, "\t"))
+	}
+
+	if hidden > 0 {
+		// No tabs: the note is prose, and a cell of it would widen the name
+		// column for every row in the tree.
+		fmt.Fprintf(out, "%s%s... and %d more (%d unhealthy shown)\n",
+			prefix, branch(true), hidden, unhealthy)
+	}
+}
+
+// limitPods applies --pod-limit. Unhealthy pods sort first, so truncation can
+// never hide the failing pod the reader is looking for.
+func limitPods(pods []workload.PodView, limit int) (shown []workload.PodView, hidden, unhealthy int) {
+	if limit < 0 || len(pods) <= limit {
+		return pods, 0, 0
+	}
+
+	ordered := slices.Clone(pods)
+	slices.SortStableFunc(ordered, func(a, b workload.PodView) int {
+		switch {
+		case a.Ready == b.Ready:
+			return 0
+		case a.Ready:
+			return 1
+		default:
+			return -1
+		}
+	})
+
+	shown = ordered[:limit]
+	for _, pod := range shown {
+		if !pod.Ready {
+			unhealthy++
+		}
+	}
+	return shown, len(ordered) - limit, unhealthy
+}
+
+func writeStatus(out io.Writer, view *workload.DescribeView) error {
+	if view.FileMode {
+		return nil
+	}
+	// Several status mappings can match at once, and hiding one would misreport
+	// the workload, so every matched phase is named.
+	if _, err := fmt.Fprintf(out, "\nPhase: %s\n", strings.Join(view.Phases, ",")); err != nil {
+		return fmt.Errorf("write status: %w", err)
+	}
+	return nil
+}
+
+// writeResources breaks the request down per component, with the workload total
+// last, so a reader can see which component accounts for the bill.
+func writeResources(out io.Writer, view *workload.DescribeView) error {
+	if _, err := fmt.Fprintln(out, "\nResources:"); err != nil {
+		return fmt.Errorf("write resources: %w", err)
+	}
+
+	writer := printers.GetNewTabWriter(out)
+	fmt.Fprintln(writer, "COMPONENT\tREPLICAS\tGPU\tCPU\tMEMORY")
+
+	var replicas int32
+	for _, component := range leaves(view.Components) {
+		replicas += component.Replicas.Desired
+		writeResourceRow(writer, component.Name, component.Replicas.Desired, component.Resources)
+	}
+	writeResourceRow(writer, "TOTAL", replicas, view.Resources)
+
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write resources: %w", err)
+	}
+	return nil
+}
+
+func writeResourceRow(out io.Writer, name string, replicas int32, request workload.Resources) {
+	fmt.Fprintf(out, "%s\t%d\t%d\t%s\t%s\n",
+		name, replicas, request.GPUs, cpu(request.CPUMillis), memory(request.MemoryBytes))
+}
+
+// leaves flattens the tree to the components that carry pods. A grouping
+// component only repeats the sum of the rows below it.
+func leaves(components []workload.ComponentView) []workload.ComponentView {
+	var out []workload.ComponentView
+	for _, component := range components {
+		if len(component.Children) == 0 {
+			out = append(out, component)
+			continue
+		}
+		out = append(out, leaves(component.Children)...)
+	}
+	return out
+}
+
+func branch(last bool) string {
+	if last {
+		return "`-- "
+	}
+	return "|-- "
+}
+
+func indent(last bool) string {
+	if last {
+		return "    "
+	}
+	return "|   "
+}
+
+func readiness(replicas workload.Replicas) string {
+	return fmt.Sprintf("%d/%d ready", replicas.Ready, replicas.Desired)
+}
+
+func podStatus(pod workload.PodView) string {
+	if pod.Reason == "" {
+		return pod.Phase
+	}
+	return fmt.Sprintf("%s (%s)", pod.Phase, pod.Reason)
+}
+
+func resourceCell(request workload.Resources) string {
+	if request.GPUs == 0 {
+		return ""
+	}
+	return fmt.Sprintf("gpu: %d", request.GPUs)
+}
+
+// cpu renders millicores the way a request is written, so 20000m reads as 20.
+func cpu(millis int64) string {
+	return resource.NewMilliQuantity(millis, resource.DecimalSI).String()
+}
+
+// memory prefers binary units and falls back to decimal, so a request written
+// as 70M renders as 70M rather than as a raw byte count.
+func memory(bytes int64) string {
+	if binary := resource.NewQuantity(bytes, resource.BinarySI).String(); strings.HasSuffix(binary, "i") {
+		return binary
+	}
+	return resource.NewQuantity(bytes, resource.DecimalSI).String()
+}
+
+func deref(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func orNone(value string) string {
+	if value == "" {
+		return "<none>"
+	}
+	return value
+}

--- a/cli/pkg/generator/describe_test.go
+++ b/cli/pkg/generator/describe_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
+	"github.com/run-ai/karta/cli/pkg/workload"
+)
+
+// decodeYAML reads yaml through json, so one struct tag set serves both.
+func decodeYAML(data []byte, into any) error { return yaml.Unmarshal(data, into) }
+
+// detailView is the worked example from the describe design: a PyTorchJob with
+// a ready master and a worker whose last replica cannot be scheduled.
+func detailView() *workload.DescribeView {
+	return &workload.DescribeView{
+		Name:       "llama-finetune",
+		Namespace:  "ml-team",
+		Kind:       "PyTorchJob",
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		Definition: "kubeflow-org-pytorchjob-v1",
+		Origin:     "catalog",
+		Phases:     []string{"Running"},
+		Resources:  workload.Resources{GPUs: 33, CPUMillis: 20000, MemoryBytes: 80 << 30},
+		Components: []workload.ComponentView{
+			{
+				Name:      "master",
+				Replicas:  workload.Replicas{Desired: 1, Current: 1, Ready: 1},
+				Resources: workload.Resources{GPUs: 1, CPUMillis: 4000, MemoryBytes: 16 << 30},
+				Nodes:     []string{"node-01"},
+				Pods: []workload.PodView{
+					{Name: "master-0", Phase: "Running", Ready: true, Node: ptr.To("node-01")},
+				},
+			},
+			{
+				Name:      "worker",
+				Replicas:  workload.Replicas{Desired: 4, Current: 4, Ready: 3},
+				Resources: workload.Resources{GPUs: 32, CPUMillis: 16000, MemoryBytes: 64 << 30},
+				Nodes:     []string{"node-02", "node-03"},
+				Pods: []workload.PodView{
+					{Name: "worker-0", Phase: "Running", Ready: true, Node: ptr.To("node-02")},
+					{Name: "worker-1", Phase: "Running", Ready: true, Node: ptr.To("node-02")},
+					{Name: "worker-2", Phase: "Running", Ready: true, Node: ptr.To("node-03")},
+					{Name: "worker-3", Phase: "Pending", Reason: "Unschedulable"},
+				},
+			},
+		},
+	}
+}
+
+func renderWorkload(view *workload.DescribeView, opts DescribeOptions) string {
+	GinkgoHelper()
+	var out bytes.Buffer
+	Expect(RenderWorkload(&out, view, opts)).To(Succeed())
+	return out.String()
+}
+
+// treeLines returns the rows between the header and the status section.
+func treeLines(out string) []string {
+	GinkgoHelper()
+	_, rest, found := strings.Cut(out, "\n")
+	Expect(found).To(BeTrue())
+	tree, _, found := strings.Cut(strings.TrimLeft(rest, "\n"), "\nPhase:")
+	Expect(found).To(BeTrue())
+	return strings.Split(strings.TrimRight(tree, "\n"), "\n")
+}
+
+var _ = Describe("RenderWorkload", func() {
+	Context("the human rendering", func() {
+		It("names the workload, its definition and its origin in the header", func() {
+			header := strings.SplitN(renderWorkload(detailView(), DescribeOptions{}), "\n", 2)[0]
+
+			Expect(header).To(ContainSubstring("PyTorchJob/llama-finetune"))
+			Expect(header).To(ContainSubstring("namespace: ml-team"))
+			Expect(header).To(ContainSubstring("definition: kubeflow-org-pytorchjob-v1 (catalog)"))
+			Expect(header).To(ContainSubstring("age: "))
+		})
+
+		It("renders every pod by default, the way kubectl-tree renders every descendant", func() {
+			lines := treeLines(renderWorkload(detailView(), DescribeOptions{}))
+
+			Expect(lines).To(HaveLen(7), "two components and five pods")
+			Expect(lines[0]).To(HavePrefix("|-- master"))
+			Expect(lines[1]).To(HavePrefix("|   `-- master-0"))
+			Expect(lines[2]).To(HavePrefix("`-- worker"))
+			Expect(lines[6]).To(HavePrefix("    `-- worker-3"))
+		})
+
+		It("reads ready counts against the desired scale, not against the pods that exist", func() {
+			Expect(treeLines(renderWorkload(detailView(), DescribeOptions{}))[2]).
+				To(ContainSubstring("3/4 ready"))
+		})
+
+		It("names why a pod is not running", func() {
+			Expect(renderWorkload(detailView(), DescribeOptions{})).
+				To(ContainSubstring("Pending (Unschedulable)"))
+		})
+
+		It("marks an unscheduled pod rather than leaving the node column blank", func() {
+			Expect(treeLines(renderWorkload(detailView(), DescribeOptions{}))[6]).
+				To(HaveSuffix("<none>"))
+		})
+
+		It("breaks resources down per component with the workload total last", func() {
+			_, resources, found := strings.Cut(renderWorkload(detailView(), DescribeOptions{}), "Resources:\n")
+			Expect(found).To(BeTrue())
+
+			rows := cells(resources)
+			Expect(rows[0]).To(Equal([]string{"COMPONENT", "REPLICAS", "GPU", "CPU", "MEMORY"}))
+			Expect(rows[1]).To(Equal([]string{"master", "1", "1", "4", "16Gi"}))
+			Expect(rows[2]).To(Equal([]string{"worker", "4", "32", "16", "64Gi"}))
+			Expect(rows[3]).To(Equal([]string{"TOTAL", "5", "33", "20", "80Gi"}))
+		})
+
+		// A request written as 70M is not a binary multiple, so binary units
+		// alone would render it as a raw byte count.
+		It("renders a decimal memory request in decimal units", func() {
+			view := detailView()
+			view.Resources = workload.Resources{MemoryBytes: 70_000_000}
+			view.Components = []workload.ComponentView{{
+				Name:      "loop",
+				Replicas:  workload.Replicas{Desired: 1},
+				Resources: workload.Resources{MemoryBytes: 70_000_000},
+			}}
+
+			_, resources, found := strings.Cut(renderWorkload(view, DescribeOptions{}), "Resources:\n")
+			Expect(found).To(BeTrue())
+			Expect(cells(resources)[1]).To(Equal([]string{"loop", "1", "0", "0", "70M"}))
+		})
+
+		It("names every matched phase, since status mappings are not exclusive", func() {
+			view := detailView()
+			view.Phases = []string{"Running", "Degraded"}
+
+			Expect(renderWorkload(view, DescribeOptions{})).To(ContainSubstring("Phase: Running,Degraded"))
+		})
+
+		Context("file mode", func() {
+			It("says the status is absent rather than rendering an empty one", func() {
+				view := detailView()
+				view.FileMode = true
+
+				out := renderWorkload(view, DescribeOptions{})
+				Expect(out).To(ContainSubstring("(file mode: no live status)"))
+				Expect(out).NotTo(ContainSubstring("Phase:"))
+				Expect(out).NotTo(ContainSubstring("age:"), "a manifest has no age")
+			})
+		})
+	})
+
+	Context("--pod-limit", func() {
+		It("shows the unhealthy pod first, so truncation cannot hide it", func() {
+			lines := treeLines(renderWorkload(detailView(), DescribeOptions{PodLimit: 2}))
+
+			Expect(lines[3]).To(ContainSubstring("worker-3"), "the first worker row is the failing one")
+			Expect(lines[5]).To(ContainSubstring("... and 2 more (1 unhealthy shown)"))
+		})
+
+		It("reports what it hid rather than truncating silently", func() {
+			Expect(renderWorkload(detailView(), DescribeOptions{PodLimit: 1})).
+				To(ContainSubstring("... and 3 more (1 unhealthy shown)"))
+		})
+
+		It("leaves a component alone when its pods fit", func() {
+			Expect(renderWorkload(detailView(), DescribeOptions{PodLimit: 4})).
+				NotTo(ContainSubstring("and 0 more"))
+		})
+
+		// The zero value is what an unset int carries, and no pod rows at all
+		// would hide the point of the command.
+		It("treats an unset limit as showing every pod", func() {
+			Expect(treeLines(renderWorkload(detailView(), DescribeOptions{}))).
+				To(Equal(treeLines(renderWorkload(detailView(), DescribeOptions{PodLimit: ShowAllPods}))))
+		})
+	})
+
+	Context("machine output", func() {
+		// An items/count envelope would say nothing about a single workload, and
+		// would cost every consumer an items[0] hop.
+		It("emits the view itself, not a list of one", func() {
+			var out bytes.Buffer
+			Expect(RenderWorkload(&out, detailView(), DescribeOptions{Output: OutputJSON})).To(Succeed())
+
+			var decoded workload.DescribeView
+			Expect(json.Unmarshal(out.Bytes(), &decoded)).To(Succeed())
+			Expect(decoded.Name).To(Equal("llama-finetune"))
+			Expect(decoded.Components).To(HaveLen(2))
+		})
+
+		// A consumer that has to re-parse "3/4" breaks silently when the human
+		// rendering changes.
+		It("carries counts and resources as numbers, never as display strings", func() {
+			var out bytes.Buffer
+			Expect(RenderWorkload(&out, detailView(), DescribeOptions{Output: OutputJSON})).To(Succeed())
+
+			var decoded map[string]any
+			Expect(json.Unmarshal(out.Bytes(), &decoded)).To(Succeed())
+			Expect(decoded["resources"]).To(HaveKeyWithValue("gpus", BeNumerically("==", 33)))
+
+			worker := decoded["components"].([]any)[1].(map[string]any)
+			Expect(worker["replicas"]).To(HaveKeyWithValue("ready", BeNumerically("==", 3)))
+			Expect(worker["replicas"]).To(HaveKeyWithValue("desired", BeNumerically("==", 4)))
+		})
+
+		It("reports an unscheduled pod as a null node", func() {
+			var out bytes.Buffer
+			Expect(RenderWorkload(&out, detailView(), DescribeOptions{Output: OutputJSON})).To(Succeed())
+
+			Expect(out.String()).To(ContainSubstring(`"node": null`))
+		})
+
+		It("agrees with json on the same view", func() {
+			view := detailView()
+
+			var asJSON, asYAML bytes.Buffer
+			Expect(RenderWorkload(&asJSON, view, DescribeOptions{Output: OutputJSON})).To(Succeed())
+			Expect(RenderWorkload(&asYAML, view, DescribeOptions{Output: OutputYAML})).To(Succeed())
+
+			var fromJSON, fromYAML workload.DescribeView
+			Expect(json.Unmarshal(asJSON.Bytes(), &fromJSON)).To(Succeed())
+			Expect(decodeYAML(asYAML.Bytes(), &fromYAML)).To(Succeed())
+			Expect(fromYAML).To(Equal(fromJSON))
+		})
+	})
+})

--- a/cli/pkg/generator/render.go
+++ b/cli/pkg/generator/render.go
@@ -31,20 +31,30 @@ func newList[T any](items []T) list[T] {
 
 // Render writes items in the machine formats and hands the human ones to table.
 func Render[T any](out io.Writer, format Output, items []T, table func(io.Writer) error) error {
+	return render(out, format, newList(items), table)
+}
+
+// RenderOne is Render for a single subject, emitted bare: an envelope would say
+// nothing there and cost a consumer an items[0] hop.
+func RenderOne[T any](out io.Writer, format Output, item T, human func(io.Writer) error) error {
+	return render(out, format, item, human)
+}
+
+func render(out io.Writer, format Output, value any, human func(io.Writer) error) error {
 	switch format {
 	case OutputTable, OutputWide:
-		return table(out)
+		return human(out)
 
 	case OutputJSON:
 		encoder := json.NewEncoder(out)
 		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(newList(items)); err != nil {
+		if err := encoder.Encode(value); err != nil {
 			return fmt.Errorf("encode as json: %w", err)
 		}
 		return nil
 
 	case OutputYAML:
-		data, err := yaml.Marshal(newList(items))
+		data, err := yaml.Marshal(value)
 		if err != nil {
 			return fmt.Errorf("encode as yaml: %w", err)
 		}


### PR DESCRIPTION
## What does this PR do?

Renders the view as header, tree, phase and per-component resources. --pod-limit defaults to showing every pod; when set, unhealthy pods sort first so truncation never hides a failing pod. The machine formats emit the view itself rather than the items/count envelope the list commands carry.

Part of a seven-PR stack implementing `kli describe` (#206). Targets `feat/cli-describe-view`, which must merge first.

## Related issue(s)

Refs #206

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workload descriptions in human-readable table, JSON, and YAML formats.
  * Displays workload metadata, component and pod trees, readiness, status, failures, scheduling details, and resource totals.
  * Supports configurable pod limits, prioritizing unhealthy pods when results are truncated.
  * Added detailed resource breakdowns, including CPU, memory, GPU, and nested component totals.
  * Added single-item rendering without an enclosing collection.
  * File-based views include format-specific details while omitting live-only status and age information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->