### PR TITLE
feat(cli): describe an unsubmitted manifest with -f

### DIFF
--- a/cli/cmd/describe.go
+++ b/cli/cmd/describe.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/cli/pkg/generator"
+	"github.com/run-ai/karta/cli/pkg/workload"
+	"github.com/run-ai/karta/pkg/catalog"
+)
+
+const (
+	flagPodLimit = "pod-limit"
+
+	usagePodLimit = "Maximum pod rows per component; the default shows every pod. " +
+		"When set, unhealthy pods are shown first"
+
+	describeUse   = "describe TYPE[/NAME] [NAME]"
+	describeShort = "Show one workload in full"
+
+	describeLong = `Show one workload as Karta reads it through the definition covering its type:
+the component tree with live pods attributed to the role they play, the
+normalized phase, and the requested resources per component.
+
+Type matching is lenient: case-insensitive, singular or plural, and kubectl short
+names all resolve.
+
+Pods are attributed by ownership, so only the pods of this workload are shown, and
+by the definition's own pod selectors, so a pod lands under the component whose
+role it plays rather than under the object that happens to own it.`
+
+	describeExample = `  # Describe a workload, kubectl-style
+  kli describe pytorchjob/llama-finetune
+
+  # Two-token form, also kubectl-style
+  kli describe pytorchjob llama-finetune
+
+  # Large workloads: cap the pod rows, unhealthy pods first
+  kli describe pytorchjob/llama-finetune --pod-limit 10
+
+  # Machine output for scripting or agents
+  kli describe pytorchjob/llama-finetune -o json`
+)
+
+// describeOptions holds one run's inputs. Embedding getOptions is what makes
+// describe accept the same TYPE/NAME forms as get.
+type describeOptions struct {
+	getOptions
+	podLimit int
+}
+
+// newDescribeCommand builds the "kli describe" command: one workload in full.
+func newDescribeCommand() *cobra.Command {
+	opts := &describeOptions{podLimit: generator.ShowAllPods}
+	var output *Enum[generator.Output]
+
+	cmd := &cobra.Command{
+		Use:     describeUse,
+		Short:   describeShort,
+		Long:    describeLong,
+		Example: describeExample,
+		Args: usageArgs(cobra.MatchAll(
+			cobra.RangeArgs(1, 2),
+			func(_ *cobra.Command, args []string) error {
+				if err := parseArgs(&opts.getOptions, args); err != nil {
+					return err
+				}
+				if opts.name == "" {
+					return fmt.Errorf(
+						"a NAME is required: give it as %s or as %s", "TYPE/NAME", "TYPE NAME")
+				}
+				return nil
+			},
+		)),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDescribe(cmd, opts, output.Get())
+		},
+	}
+
+	// A single workload renders no extra columns, so wide is rejected at parse
+	// time rather than silently treated as the table.
+	output = withOutput(cmd, cmd.Flags(), false)
+	cmd.Flags().IntVar(&opts.podLimit, flagPodLimit, generator.ShowAllPods, usagePodLimit)
+
+	return cmd
+}
+
+func runDescribe(cmd *cobra.Command, opts *describeOptions, format generator.Output) error {
+	ctx := cmd.Context()
+	access := clusterAccess()
+
+	namespace, _, err := ResolvedNamespace(access)
+	if err != nil {
+		return fmt.Errorf("resolve namespace: %w", err)
+	}
+
+	resolver, warnings := loadDefinitions(ctx, access)
+	if err := printWarnings(cmd.ErrOrStderr(), warningMessages(warnings)); err != nil {
+		return err
+	}
+
+	mapper, err := access.ToRESTMapper()
+	if err != nil {
+		return fmt.Errorf("kubernetes discovery: %w", err)
+	}
+	dyn, err := newDynamicClient(access)
+	if err != nil {
+		return err
+	}
+
+	target, err := resolveTarget(&opts.getOptions, resolver, mapper)
+	if err != nil {
+		return err
+	}
+
+	obj, err := getOne(ctx, dyn, mapper, target, namespace, opts.name)
+	if err != nil {
+		return err
+	}
+
+	// Pods are read from the object's own namespace: a workload's pods are
+	// created beside it, and the request must not widen when -n was omitted.
+	pods, err := workload.ListPods(ctx, dyn, obj.GetNamespace())
+	if err != nil {
+		return fmt.Errorf("list pods: %w", err)
+	}
+	mine, err := workload.NewPodAttributor(dyn, mapper).Filter(ctx, pods, obj.GetUID())
+	if err != nil {
+		return fmt.Errorf("attribute pods: %w", err)
+	}
+
+	view, err := workload.ResolveDescribe(ctx, obj, target, mine)
+	if err != nil {
+		return fmt.Errorf("describe %s %q: %w", obj.GetKind(), obj.GetName(), err)
+	}
+
+	return generator.RenderWorkload(cmd.OutOrStdout(), view, generator.DescribeOptions{
+		Output:   format,
+		PodLimit: opts.podLimit,
+	})
+}
+
+// getOne fetches the single named object of target's type, reporting a miss the
+// way get reports one so a script sees the same code either way.
+func getOne(
+	ctx context.Context,
+	dyn dynamic.Interface,
+	mapper meta.RESTMapper,
+	target definitions.Definition,
+	namespace, name string,
+) (*unstructured.Unstructured, error) {
+	gvk := catalog.RootKey(target.Karta)
+
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	switch {
+	case err == nil:
+	case meta.IsNoMatchError(err):
+		// The type is absent, so the named workload cannot exist.
+		return nil, exitError{code: ExitWorkloadNotFound,
+			err: fmt.Errorf("%s is not installed in this cluster", gvk.Kind)}
+	default:
+		return nil, fmt.Errorf("discover %s: %w", gvk.Kind, err)
+	}
+
+	// A cluster-scoped root is not addressed by namespace.
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		namespace = ""
+	}
+
+	obj, err := dyn.Resource(mapping.Resource).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	switch {
+	case err == nil:
+		return obj, nil
+	case apierrors.IsNotFound(err):
+		return nil, exitError{code: ExitWorkloadNotFound,
+			err: fmt.Errorf("%s %q not found%s", gvk.Kind, name, inNamespace(namespace))}
+	case apierrors.IsForbidden(err):
+		return nil, exitError{code: ExitError,
+			err: fmt.Errorf("not allowed to read %s: %w", gvk.Kind, err)}
+	default:
+		return nil, exitError{code: ExitError,
+			err: fmt.Errorf("get %s %q: %w", gvk.Kind, name, err)}
+	}
+}

--- a/cli/cmd/describe.go
+++ b/cli/cmd/describe.go
@@ -5,14 +5,21 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
 
 	"github.com/run-ai/karta/cli/pkg/definitions"
 	"github.com/run-ai/karta/cli/pkg/generator"
@@ -22,9 +29,12 @@ import (
 
 const (
 	flagPodLimit = "pod-limit"
+	flagFile     = "file"
 
 	usagePodLimit = "Maximum pod rows per component; the default shows every pod. " +
 		"When set, unhealthy pods are shown first"
+	usageFile = "Describe a manifest that has not been submitted; \"-\" reads stdin. " +
+		"No cluster is needed, and no TYPE/NAME is accepted"
 
 	describeUse   = "describe TYPE[/NAME] [NAME]"
 	describeShort = "Show one workload in full"
@@ -38,7 +48,11 @@ names all resolve.
 
 Pods are attributed by ownership, so only the pods of this workload are shown, and
 by the definition's own pod selectors, so a pod lands under the component whose
-role it plays rather than under the object that happens to own it.`
+role it plays rather than under the object that happens to own it.
+
+With -f, the same view is built from a manifest alone, with no cluster and no
+pods: the structure and the desired scale are real, everything live is absent.
+It answers what a workload would look like before it is submitted.`
 
 	describeExample = `  # Describe a workload, kubectl-style
   kli describe pytorchjob/llama-finetune
@@ -49,6 +63,9 @@ role it plays rather than under the object that happens to own it.`
   # Large workloads: cap the pod rows, unhealthy pods first
   kli describe pytorchjob/llama-finetune --pod-limit 10
 
+  # Validate a manifest before submitting it, no cluster needed
+  kli describe -f jobset.yaml
+
   # Machine output for scripting or agents
   kli describe pytorchjob/llama-finetune -o json`
 )
@@ -58,6 +75,7 @@ role it plays rather than under the object that happens to own it.`
 type describeOptions struct {
 	getOptions
 	podLimit int
+	file     string
 }
 
 // newDescribeCommand builds the "kli describe" command: one workload in full.
@@ -70,19 +88,29 @@ func newDescribeCommand() *cobra.Command {
 		Short:   describeShort,
 		Long:    describeLong,
 		Example: describeExample,
-		Args: usageArgs(cobra.MatchAll(
-			cobra.RangeArgs(1, 2),
-			func(_ *cobra.Command, args []string) error {
-				if err := parseArgs(&opts.getOptions, args); err != nil {
-					return err
-				}
-				if opts.name == "" {
+		// The range applies to the positional form only: -f reads the kind from
+		// the manifest, so it takes no arguments at all.
+		Args: usageArgs(func(cmd *cobra.Command, args []string) error {
+			if opts.file != "" {
+				if len(args) > 0 {
 					return fmt.Errorf(
-						"a NAME is required: give it as %s or as %s", "TYPE/NAME", "TYPE NAME")
+						"--%s reads the kind from the manifest, so it cannot be combined with %q",
+						flagFile, strings.Join(args, " "))
 				}
 				return nil
-			},
-		)),
+			}
+			if err := cobra.RangeArgs(1, 2)(cmd, args); err != nil {
+				return err
+			}
+			if err := parseArgs(&opts.getOptions, args); err != nil {
+				return err
+			}
+			if opts.name == "" {
+				return fmt.Errorf(
+					"a NAME is required: give it as %s or as %s", "TYPE/NAME", "TYPE NAME")
+			}
+			return nil
+		}),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runDescribe(cmd, opts, output.Get())
 		},
@@ -92,6 +120,7 @@ func newDescribeCommand() *cobra.Command {
 	// time rather than silently treated as the table.
 	output = withOutput(cmd, cmd.Flags(), false)
 	cmd.Flags().IntVar(&opts.podLimit, flagPodLimit, generator.ShowAllPods, usagePodLimit)
+	cmd.Flags().StringVarP(&opts.file, flagFile, "f", "", usageFile)
 
 	return cmd
 }
@@ -100,55 +129,206 @@ func runDescribe(cmd *cobra.Command, opts *describeOptions, format generator.Out
 	ctx := cmd.Context()
 	access := clusterAccess()
 
-	namespace, _, err := ResolvedNamespace(access)
-	if err != nil {
-		return fmt.Errorf("resolve namespace: %w", err)
-	}
-
+	// Read best-effort: an unreachable cluster degrades to the embedded catalog,
+	// which is what lets file mode work with no cluster at all.
 	resolver, warnings := loadDefinitions(ctx, access)
 	if err := printWarnings(cmd.ErrOrStderr(), warningMessages(warnings)); err != nil {
 		return err
 	}
 
-	mapper, err := access.ToRESTMapper()
+	view, err := resolveView(ctx, cmd, opts, resolver, access)
 	if err != nil {
-		return fmt.Errorf("kubernetes discovery: %w", err)
-	}
-	dyn, err := newDynamicClient(access)
-	if err != nil {
-		return err
-	}
-
-	target, err := resolveTarget(&opts.getOptions, resolver, mapper)
-	if err != nil {
-		return err
-	}
-
-	obj, err := getOne(ctx, dyn, mapper, target, namespace, opts.name)
-	if err != nil {
-		return err
-	}
-
-	// Pods are read from the object's own namespace: a workload's pods are
-	// created beside it, and the request must not widen when -n was omitted.
-	pods, err := workload.ListPods(ctx, dyn, obj.GetNamespace())
-	if err != nil {
-		return fmt.Errorf("list pods: %w", err)
-	}
-	mine, err := workload.NewPodAttributor(dyn, mapper).Filter(ctx, pods, obj.GetUID())
-	if err != nil {
-		return fmt.Errorf("attribute pods: %w", err)
-	}
-
-	view, err := workload.ResolveDescribe(ctx, obj, target, mine)
-	if err != nil {
-		return fmt.Errorf("describe %s %q: %w", obj.GetKind(), obj.GetName(), err)
+		return reportNoDefinition(cmd, format, err)
 	}
 
 	return generator.RenderWorkload(cmd.OutOrStdout(), view, generator.DescribeOptions{
 		Output:   format,
 		PodLimit: opts.podLimit,
 	})
+}
+
+func resolveView(
+	ctx context.Context,
+	cmd *cobra.Command,
+	opts *describeOptions,
+	resolver *definitions.Resolver,
+	access genericclioptions.RESTClientGetter,
+) (*workload.DescribeView, error) {
+	if opts.file != "" {
+		return describeManifest(ctx, cmd, opts, resolver)
+	}
+	return describeLive(ctx, opts, resolver, access)
+}
+
+// describeLive reads the named workload and its pods from the cluster.
+func describeLive(
+	ctx context.Context,
+	opts *describeOptions,
+	resolver *definitions.Resolver,
+	access genericclioptions.RESTClientGetter,
+) (*workload.DescribeView, error) {
+	namespace, _, err := ResolvedNamespace(access)
+	if err != nil {
+		return nil, fmt.Errorf("resolve namespace: %w", err)
+	}
+
+	mapper, err := access.ToRESTMapper()
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes discovery: %w", err)
+	}
+	dyn, err := newDynamicClient(access)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := resolveTarget(&opts.getOptions, resolver, mapper)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := getOne(ctx, dyn, mapper, target, namespace, opts.name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Pods are read from the object's own namespace: a workload's pods are
+	// created beside it, and the request must not widen when -n was omitted.
+	pods, err := workload.ListPods(ctx, dyn, obj.GetNamespace())
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+	mine, err := workload.NewPodAttributor(dyn, mapper).Filter(ctx, pods, obj.GetUID())
+	if err != nil {
+		return nil, fmt.Errorf("attribute pods: %w", err)
+	}
+
+	view, err := workload.ResolveDescribe(ctx, obj, target, mine)
+	if err != nil {
+		return nil, fmt.Errorf("describe %s %q: %w", obj.GetKind(), obj.GetName(), err)
+	}
+	return view, nil
+}
+
+// describeManifest builds the view from a manifest alone. The kind comes from
+// the manifest, so no discovery is involved and no cluster is required.
+func describeManifest(
+	ctx context.Context, cmd *cobra.Command, opts *describeOptions, resolver *definitions.Resolver,
+) (*workload.DescribeView, error) {
+	obj, err := readManifest(cmd, opts.file)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := obj.GroupVersionKind()
+	if gvk.Kind == "" || gvk.Version == "" {
+		return nil, usageError(cmd, fmt.Errorf(
+			"%s declares no apiVersion and kind, so there is nothing to resolve it by", opts.file))
+	}
+
+	target, err := resolver.Resolve(gvk)
+	switch {
+	case err == nil:
+	case errors.Is(err, definitions.ErrAmbiguous):
+		return nil, exitError{code: ExitUsage, err: err}
+	default:
+		return nil, noDefinitionFor(gvk)
+	}
+
+	// No pods: a manifest that never reached the cluster has none, and inventing
+	// zeroes would read as a workload whose pods have all gone.
+	view, err := workload.ResolveDescribe(ctx, obj, target, nil)
+	if err != nil {
+		return nil, fmt.Errorf("describe %s: %w", opts.file, err)
+	}
+	view.FileMode = true
+	return view, nil
+}
+
+// readManifest decodes one workload manifest, from stdin when path is "-".
+func readManifest(cmd *cobra.Command, path string) (*unstructured.Unstructured, error) {
+	var (
+		raw []byte
+		err error
+	)
+	if path == "-" {
+		raw, err = io.ReadAll(cmd.InOrStdin())
+	} else {
+		raw, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	// A plain map, not Unstructured: its unmarshal rejects a missing kind with a
+	// message about JSON internals rather than the field that is absent.
+	var fields map[string]any
+	if err := yaml.Unmarshal(raw, &fields); err != nil {
+		return nil, usageError(cmd, fmt.Errorf("parse %s: %w", path, err))
+	}
+	return &unstructured.Unstructured{Object: fields}, nil
+}
+
+// machineError is the shape a failure takes in the machine formats. Only the
+// no-definition case uses it, being the one an agent handles differently.
+type machineError struct {
+	Error   string `json:"error"`
+	GVK     string `json:"gvk,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Message string `json:"message"`
+	Hint    string `json:"hint"`
+}
+
+const (
+	noDefinitionReason  = "no_definition_for_type"
+	noDefinitionMessage = "no Karta definition covers this workload type"
+	noDefinitionHint    = `"kli definitions" lists the types Karta covers; ` +
+		"apply a Karta definition to the cluster to cover this one"
+)
+
+// noDefinitionNotFound marks a failure reportNoDefinition should also emit as a
+// machine error, carrying the identity the payload names.
+type noDefinitionNotFound struct {
+	exitError
+	subject machineError
+}
+
+func noDefinitionFor(gvk schema.GroupVersionKind) error {
+	return noDefinitionNotFound{
+		exitError: exitError{code: ExitNotFound,
+			err: fmt.Errorf("%s: %s", noDefinitionMessage, gvk)},
+		subject: machineError{
+			Error: noDefinitionReason, GVK: gvk.String(),
+			Message: noDefinitionMessage, Hint: noDefinitionHint,
+		},
+	}
+}
+
+// reportNoDefinition puts the machine error on stdout, where an agent reads,
+// and leaves the human message on stderr, where a reader does.
+func reportNoDefinition(cmd *cobra.Command, format generator.Output, err error) error {
+	if format != generator.OutputJSON && format != generator.OutputYAML {
+		return err
+	}
+
+	var structured noDefinitionNotFound
+	if !errors.As(err, &structured) {
+		// A type token that matched no definition carries no GVK to name, so
+		// the payload names the token the caller used instead.
+		var coded exitError
+		if !errors.As(err, &coded) || coded.code != ExitNotFound {
+			return err
+		}
+		structured.subject = machineError{
+			Error: noDefinitionReason, Type: coded.Error(),
+			Message: noDefinitionMessage, Hint: noDefinitionHint,
+		}
+	}
+
+	if writeErr := generator.RenderOne(cmd.OutOrStdout(), format, structured.subject,
+		func(io.Writer) error { return nil }); writeErr != nil {
+		return writeErr
+	}
+	return err
 }
 
 // getOne fetches the single named object of target's type, reporting a miss the

--- a/cli/cmd/describe_test.go
+++ b/cli/cmd/describe_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -313,5 +315,215 @@ func TestDescribeShowsEveryPodByDefault(t *testing.T) {
 	}
 	if strings.Contains(out, "more (") {
 		t.Errorf("nothing should be truncated by default\n%s", out)
+	}
+}
+
+// noCluster points the command tree at a kubeconfig-less environment, which is
+// what file mode is for and what keeps these tests off any real cluster.
+func noCluster(t *testing.T) {
+	t.Helper()
+
+	restore := clusterAccess
+	clusterAccess = noClusterGetter
+	t.Cleanup(func() { clusterAccess = restore })
+}
+
+// writeManifest puts a manifest in a temp file and returns its path.
+func writeManifest(t *testing.T, manifest string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "workload.yaml")
+	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+const jobSetManifest = `apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: preprocess
+  namespace: ml-team
+spec:
+  replicatedJobs:
+    - name: etl
+      replicas: 1
+      template:
+        spec:
+          parallelism: 3
+          template:
+            spec:
+              containers:
+                - name: worker
+                  resources:
+                    requests:
+                      nvidia.com/gpu: "2"
+`
+
+// File mode is for a manifest that has not been submitted, so it must not need
+// a cluster to answer.
+func TestDescribeFileModeNeedsNoCluster(t *testing.T) {
+	noCluster(t)
+
+	out, errOut, code := runDescribeCmd(t, "-f", writeManifest(t, jobSetManifest))
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, errOut)
+	}
+	for _, want := range []string{
+		"JobSet/preprocess", "(file mode: no live status)", "replicatedjob", "Resources:", "TOTAL",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Phase:") {
+		t.Errorf("a manifest that never reached the cluster has no phase\n%s", out)
+	}
+}
+
+func TestDescribeFileModeReadsStdin(t *testing.T) {
+	noCluster(t)
+
+	root := NewRootCommand()
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetIn(strings.NewReader(jobSetManifest))
+	root.SetArgs([]string{"describe", "-f", "-"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("expected success, got %v\n%s", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "JobSet/preprocess") {
+		t.Errorf("expected the workload header\n%s", out.String())
+	}
+}
+
+// Live mode and file mode answer the same question, so they must answer it in
+// the same shape; only the live fields differ.
+func TestDescribeFileModeSharesTheLiveShape(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3))
+	live, _, code := runDescribeCmd(t, "jobset/preprocess", "-o", "json")
+	if code != 0 {
+		t.Fatalf("live: expected exit 0, got %d\n%s", code, live)
+	}
+
+	fromFile, _, code := runDescribeCmd(t, "-f", writeManifest(t, jobSetManifest), "-o", "json")
+	if code != 0 {
+		t.Fatalf("file: expected exit 0, got %d\n%s", code, fromFile)
+	}
+
+	var liveKeys, fileKeys map[string]any
+	if err := json.Unmarshal([]byte(live), &liveKeys); err != nil {
+		t.Fatalf("decode live: %v", err)
+	}
+	if err := json.Unmarshal([]byte(fromFile), &fileKeys); err != nil {
+		t.Fatalf("decode file: %v", err)
+	}
+	for key := range liveKeys {
+		if _, ok := fileKeys[key]; !ok {
+			t.Errorf("file mode dropped the %q field instead of leaving it empty", key)
+		}
+	}
+	if fileKeys["fileMode"] != true {
+		t.Errorf("expected fileMode to be marked, got %v", fileKeys["fileMode"])
+	}
+}
+
+// The no-definition case is the one an agent handles differently from every
+// other failure, so with a machine format it is emitted as a parseable object.
+func TestDescribeFileModeStructuredNoDefinitionError(t *testing.T) {
+	noCluster(t)
+
+	path := writeManifest(t, `apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: etl
+`)
+
+	out, errOut, code := runDescribeCmd(t, "-f", path, "-o", "json")
+	if code != ExitNotFound {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitNotFound, code, errOut)
+	}
+
+	var reported struct {
+		Error   string `json:"error"`
+		GVK     string `json:"gvk"`
+		Message string `json:"message"`
+		Hint    string `json:"hint"`
+	}
+	if err := json.Unmarshal([]byte(out), &reported); err != nil {
+		t.Fatalf("decode json: %v\n%s", err, out)
+	}
+	if reported.Error != "no_definition_for_type" {
+		t.Errorf("unexpected reason %q", reported.Error)
+	}
+	if !strings.Contains(reported.GVK, "FlinkDeployment") {
+		t.Errorf("the payload must name the type it could not cover, got %q", reported.GVK)
+	}
+	if reported.Message == "" || reported.Hint == "" {
+		t.Errorf("expected a message and a hint, got %+v", reported)
+	}
+	// A human watching stderr must be told too.
+	if !strings.Contains(errOut, "no Karta definition covers") {
+		t.Errorf("expected the human message on stderr\n%s", errOut)
+	}
+}
+
+// The table is for a reader, who is served by the plain message.
+func TestDescribeNoDefinitionStaysPlainForTheTable(t *testing.T) {
+	noCluster(t)
+
+	path := writeManifest(t, `apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: etl
+`)
+
+	out, errOut, code := runDescribeCmd(t, "-f", path)
+	if code != ExitNotFound {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitNotFound, code, errOut)
+	}
+	if out != "" {
+		t.Errorf("nothing should reach stdout\n%s", out)
+	}
+	if !strings.Contains(errOut, "no Karta definition covers") {
+		t.Errorf("unexpected message: %s", errOut)
+	}
+}
+
+func TestDescribeFileModeRejectsAPositionalArgument(t *testing.T) {
+	noCluster(t)
+
+	_, errOut, code := runDescribeCmd(t, "-f", writeManifest(t, jobSetManifest), "jobset/preprocess")
+	if code != ExitUsage {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitUsage, code, errOut)
+	}
+	if !strings.Contains(errOut, "cannot be combined") {
+		t.Errorf("unexpected message: %s", errOut)
+	}
+}
+
+func TestDescribeFileModeRejectsAManifestWithNoKind(t *testing.T) {
+	noCluster(t)
+
+	_, errOut, code := runDescribeCmd(t, "-f", writeManifest(t, "metadata:\n  name: etl\n"))
+	if code != ExitUsage {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitUsage, code, errOut)
+	}
+	if !strings.Contains(errOut, "apiVersion and kind") {
+		t.Errorf("unexpected message: %s", errOut)
+	}
+}
+
+func TestDescribeFileModeReportsAnUnreadableFile(t *testing.T) {
+	noCluster(t)
+
+	_, errOut, code := runDescribeCmd(t, "-f", filepath.Join(t.TempDir(), "absent.yaml"))
+	if code != ExitError {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitError, code, errOut)
+	}
+	if !strings.Contains(errOut, "read ") {
+		t.Errorf("unexpected message: %s", errOut)
 	}
 }

--- a/cli/cmd/describe_test.go
+++ b/cli/cmd/describe_test.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+var (
+	podGVK = schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+	podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+)
+
+// etlPod builds a pod of the JobSet fixture's "etl" replicated job, owned by
+// the JobSet whose uid is given, so the attributor can claim it.
+func etlPod(name, owner, node string, ready bool) *unstructured.Unstructured {
+	status := map[string]any{
+		"phase": "Running",
+		"conditions": []any{map[string]any{
+			"type": "Ready", "status": "True",
+		}},
+	}
+	spec := map[string]any{
+		"nodeName": node,
+		"containers": []any{map[string]any{
+			"name": "worker",
+			"resources": map[string]any{
+				"requests": map[string]any{"nvidia.com/gpu": "2"},
+			},
+		}},
+	}
+	if !ready {
+		status = map[string]any{
+			"phase": "Pending",
+			"conditions": []any{map[string]any{
+				"type": "PodScheduled", "status": "False", "reason": "Unschedulable",
+			}},
+		}
+		delete(spec, "nodeName")
+	}
+
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name": name, "namespace": "ml-team",
+			"labels": map[string]any{"jobset.sigs.k8s.io/replicatedjob-name": "etl"},
+			"ownerReferences": []any{map[string]any{
+				"apiVersion": jobSetGVK.GroupVersion().String(),
+				"kind":       jobSetGVK.Kind,
+				"name":       strings.TrimPrefix(owner, "ml-team/"),
+				"uid":        owner,
+				"controller": true,
+			}},
+		},
+		"spec":   spec,
+		"status": status,
+	}}
+}
+
+// describeCluster points the command tree at an in-memory cluster serving
+// JobSets and the pods that belong to them.
+func describeCluster(t *testing.T, objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			jobSetGVR: "JobSetList",
+			podGVR:    "PodList",
+		}, objects...)
+
+	mapper := meta.NewDefaultRESTMapper(nil)
+	mapper.AddSpecific(jobSetGVK, jobSetGVR, jobSetGVK.GroupVersion().WithResource("jobset"), meta.RESTScopeNamespace)
+	mapper.Add(podGVK, meta.RESTScopeNamespace)
+
+	restore := newDynamicClient
+	newDynamicClient = func(genericclioptions.RESTClientGetter) (dynamic.Interface, error) { return client, nil }
+	t.Cleanup(func() { newDynamicClient = restore })
+
+	flags := genericclioptions.NewTestConfigFlags().
+		WithClientConfig(clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), nil)).
+		WithNamespace("ml-team").
+		WithRESTMapper(mapper)
+
+	restoreAccess := clusterAccess
+	clusterAccess = func() genericclioptions.RESTClientGetter { return flags }
+	t.Cleanup(func() { clusterAccess = restoreAccess })
+
+	return client
+}
+
+// runDescribeCmd executes "kli describe" with args, returning stdout, stderr
+// and the exit code the binary would produce.
+func runDescribeCmd(t *testing.T, args ...string) (string, string, int) {
+	t.Helper()
+
+	root := NewRootCommand()
+	var out, errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetArgs(append([]string{"describe"}, args...))
+
+	code := 0
+	if err := root.Execute(); err != nil {
+		code = 1
+		var coded interface{ ExitCode() int }
+		if errors.As(err, &coded) {
+			code = coded.ExitCode()
+		}
+		errOut.WriteString("error: " + err.Error() + "\n")
+	}
+	return out.String(), errOut.String(), code
+}
+
+func TestDescribeRendersEverySection(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3),
+		etlPod("preprocess-etl-0", "ml-team/preprocess", "node-01", true),
+		etlPod("preprocess-etl-1", "ml-team/preprocess", "node-02", true))
+
+	out, errOut, code := runDescribeCmd(t, "jobset/preprocess")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, errOut)
+	}
+	for _, want := range []string{
+		"JobSet/preprocess", "namespace: ml-team", "definition: jobset-x-k8s-io-jobset-v1alpha2",
+		"age: ", "preprocess-etl-0", "node-01", "Phase:", "Resources:", "TOTAL",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+}
+
+// A selector says which role a pod plays, never which workload it belongs to,
+// so only ownership keeps a neighbour's pods out of this workload's tree.
+func TestDescribeShowsOnlyThisWorkloadsPods(t *testing.T) {
+	describeCluster(t,
+		jobSet("preprocess", 3), jobSet("neighbour", 3),
+		etlPod("preprocess-etl-0", "ml-team/preprocess", "node-01", true),
+		etlPod("neighbour-etl-0", "ml-team/neighbour", "node-09", true))
+
+	out, _, code := runDescribeCmd(t, "jobset/preprocess")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, out)
+	}
+	if !strings.Contains(out, "preprocess-etl-0") {
+		t.Errorf("expected this workload's pod\n%s", out)
+	}
+	if strings.Contains(out, "neighbour-etl-0") {
+		t.Errorf("another workload's pod leaked into the tree\n%s", out)
+	}
+}
+
+func TestDescribeAcceptsBothArgumentForms(t *testing.T) {
+	for _, args := range [][]string{
+		{"jobset/preprocess"},
+		{"jobset", "preprocess"},
+		{"JobSet/preprocess"},
+		{"jobsets/preprocess"},
+	} {
+		describeCluster(t, jobSet("preprocess", 3))
+
+		out, errOut, code := runDescribeCmd(t, args...)
+		if code != 0 {
+			t.Errorf("%v: expected exit 0, got %d\n%s", args, code, errOut)
+			continue
+		}
+		if !strings.Contains(out, "JobSet/preprocess") {
+			t.Errorf("%v: expected the workload header\n%s", args, out)
+		}
+	}
+}
+
+// Phase 1 requires the kind, and the message has to show a reader both forms
+// rather than only the one they did not use.
+func TestDescribeRequiresAName(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3))
+
+	_, errOut, code := runDescribeCmd(t, "jobset")
+	if code != ExitUsage {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitUsage, code, errOut)
+	}
+	for _, want := range []string{"TYPE/NAME", "TYPE NAME"} {
+		if !strings.Contains(errOut, want) {
+			t.Errorf("message missing %q\n%s", want, errOut)
+		}
+	}
+}
+
+func TestDescribeMissingWorkloadIsItsOwnFailure(t *testing.T) {
+	describeCluster(t)
+
+	_, errOut, code := runDescribeCmd(t, "jobset/absent")
+	if code != ExitWorkloadNotFound {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitWorkloadNotFound, code, errOut)
+	}
+	if !strings.Contains(errOut, "not found") {
+		t.Errorf("unexpected message: %s", errOut)
+	}
+}
+
+// An agent's fallback for a type Karta does not cover - author a definition -
+// differs from every other failure, so it must be tellable apart.
+func TestDescribeUncoveredTypeIsItsOwnFailure(t *testing.T) {
+	describeCluster(t)
+
+	_, errOut, code := runDescribeCmd(t, "flinkdeployment/etl")
+	if code != ExitNotFound {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitNotFound, code, errOut)
+	}
+	if !strings.Contains(errOut, "no Karta definition covers") {
+		t.Errorf("unexpected message: %s", errOut)
+	}
+}
+
+// One workload renders no extra columns, so wide has no meaning here and is
+// rejected rather than silently treated as the table.
+func TestDescribeRejectsWide(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3))
+
+	_, errOut, code := runDescribeCmd(t, "jobset/preprocess", "-o", "wide")
+	if code != ExitUsage {
+		t.Fatalf("expected exit %d, got %d\n%s", ExitUsage, code, errOut)
+	}
+	if !strings.Contains(errOut, "must be one of table, json, yaml") {
+		t.Errorf("unexpected message: %s", errOut)
+	}
+}
+
+func TestDescribeMachineOutputIsTheViewItself(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3),
+		etlPod("preprocess-etl-0", "ml-team/preprocess", "node-01", true))
+
+	out, errOut, code := runDescribeCmd(t, "jobset/preprocess", "-o", "json")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, errOut)
+	}
+
+	var view struct {
+		Name       string `json:"name"`
+		Kind       string `json:"kind"`
+		Components []struct {
+			Replicas struct {
+				Desired int `json:"desired"`
+				Ready   int `json:"ready"`
+			} `json:"replicas"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal([]byte(out), &view); err != nil {
+		t.Fatalf("decode json: %v\n%s", err, out)
+	}
+	if view.Name != "preprocess" || view.Kind != "JobSet" {
+		t.Errorf("unexpected workload: %+v", view)
+	}
+	if len(view.Components) == 0 {
+		t.Fatalf("expected components\n%s", out)
+	}
+	if view.Components[0].Replicas.Ready != 1 {
+		t.Errorf("expected a typed ready count, got %+v", view.Components[0].Replicas)
+	}
+	if strings.Contains(out, `"items"`) {
+		t.Errorf("a single workload should not be wrapped in a list envelope\n%s", out)
+	}
+}
+
+func TestDescribePodLimitKeepsTheFailingPod(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3),
+		etlPod("preprocess-etl-0", "ml-team/preprocess", "node-01", true),
+		etlPod("preprocess-etl-1", "ml-team/preprocess", "node-02", true),
+		etlPod("preprocess-etl-2", "ml-team/preprocess", "", false))
+
+	out, errOut, code := runDescribeCmd(t, "jobset/preprocess", "--pod-limit", "1")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, errOut)
+	}
+	if !strings.Contains(out, "preprocess-etl-2") {
+		t.Errorf("truncation hid the unschedulable pod\n%s", out)
+	}
+	if !strings.Contains(out, "... and 2 more (1 unhealthy shown)") {
+		t.Errorf("expected the truncation note\n%s", out)
+	}
+}
+
+func TestDescribeShowsEveryPodByDefault(t *testing.T) {
+	describeCluster(t, jobSet("preprocess", 3),
+		etlPod("preprocess-etl-0", "ml-team/preprocess", "node-01", true),
+		etlPod("preprocess-etl-1", "ml-team/preprocess", "node-02", true),
+		etlPod("preprocess-etl-2", "ml-team/preprocess", "node-03", true))
+
+	out, _, code := runDescribeCmd(t, "jobset/preprocess")
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d\n%s", code, out)
+	}
+	for _, name := range []string{"preprocess-etl-0", "preprocess-etl-1", "preprocess-etl-2"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("output missing %q\n%s", name, out)
+		}
+	}
+	if strings.Contains(out, "more (") {
+		t.Errorf("nothing should be truncated by default\n%s", out)
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -66,6 +66,7 @@ func NewRootCommand() *cobra.Command {
 	withConfig(cmd)
 
 	cmd.AddCommand(newGetCommand())
+	cmd.AddCommand(newDescribeCommand())
 	cmd.AddCommand(newDefinitionsCommand(kubeFlags))
 
 	cmd.InitDefaultCompletionCmd()

--- a/cli/pkg/generator/describe.go
+++ b/cli/pkg/generator/describe.go
@@ -98,27 +98,36 @@ func writeTree(out io.Writer, view *workload.DescribeView, limit int) error {
 	}
 
 	writer := printers.GetNewTabWriter(out)
-	writeComponents(writer, view.Components, "", limit)
+	writeComponents(writer, view.Components, "", limit, view.FileMode)
 	if err := writer.Flush(); err != nil {
 		return fmt.Errorf("write tree: %w", err)
 	}
 	return nil
 }
 
-func writeComponents(out io.Writer, components []workload.ComponentView, prefix string, limit int) {
+func writeComponents(out io.Writer, components []workload.ComponentView, prefix string, limit int, fileMode bool) {
 	for i, component := range components {
 		last := i == len(components)-1
-		fmt.Fprintln(out, strings.Join([]string{
-			prefix + branch(last) + component.Name,
-			readiness(component.Replicas),
+		fmt.Fprintln(out, row(
+			prefix+branch(last)+component.Name,
+			scale(component.Replicas, fileMode),
 			resourceCell(component.Resources),
 			strings.Join(component.Nodes, ","),
-		}, "\t"))
+		))
 
 		childPrefix := prefix + indent(last)
 		writePods(out, component.Pods, childPrefix, limit)
-		writeComponents(out, component.Children, childPrefix, limit)
+		writeComponents(out, component.Children, childPrefix, limit, fileMode)
 	}
+}
+
+// row joins cells for the tab writer, dropping the empty ones at the end: a
+// trailing tab pads the line with spaces no reader sees but every diff does.
+func row(cells ...string) string {
+	for len(cells) > 0 && cells[len(cells)-1] == "" {
+		cells = cells[:len(cells)-1]
+	}
+	return strings.Join(cells, "\t")
 }
 
 func writePods(out io.Writer, pods []workload.PodView, prefix string, limit int) {
@@ -128,12 +137,12 @@ func writePods(out io.Writer, pods []workload.PodView, prefix string, limit int)
 		// The truncation line is the last row under this component, so a shown
 		// pod is only "last" when nothing follows it.
 		last := i == len(shown)-1 && hidden == 0
-		fmt.Fprintln(out, strings.Join([]string{
-			prefix + branch(last) + pod.Name,
+		fmt.Fprintln(out, row(
+			prefix+branch(last)+pod.Name,
 			podStatus(pod),
 			resourceCell(pod.Resources),
 			orNone(deref(pod.Node)),
-		}, "\t"))
+		))
 	}
 
 	if hidden > 0 {
@@ -240,7 +249,12 @@ func indent(last bool) string {
 	return "|   "
 }
 
-func readiness(replicas workload.Replicas) string {
+// scale reports readiness against the desired count. File mode has no pods, so
+// it reports the count alone; "0/9 ready" would read as nine that failed.
+func scale(replicas workload.Replicas, fileMode bool) string {
+	if fileMode {
+		return fmt.Sprintf("replicas: %d", replicas.Desired)
+	}
 	return fmt.Sprintf("%d/%d ready", replicas.Ready, replicas.Desired)
 }
 

--- a/cli/pkg/generator/describe.go
+++ b/cli/pkg/generator/describe.go
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	"github.com/run-ai/karta/cli/pkg/workload"
+)
+
+// ShowAllPods is the --pod-limit default: a hidden pod is the one a reader most
+// needs to see.
+const ShowAllPods = -1
+
+// fileModeNote marks output built from a manifest that never reached a cluster,
+// so an empty status section reads as "not applicable" and not as "healthy".
+const fileModeNote = "(file mode: no live status)"
+
+// DescribeOptions controls how one workload is rendered.
+type DescribeOptions struct {
+	// Output selects the format. The zero value renders the default table, so
+	// DescribeOptions{} is usable as-is.
+	Output Output
+	// PodLimit caps the pod rows per component. Negative shows every pod.
+	PodLimit int
+}
+
+// RenderWorkload writes one workload to out. The machine formats emit the view
+// itself, so what a human reads and what an agent parses cannot drift.
+func RenderWorkload(out io.Writer, view *workload.DescribeView, opts DescribeOptions) error {
+	format := opts.Output
+	if format == "" {
+		format = OutputTable
+	}
+
+	limit := opts.PodLimit
+	if opts.PodLimit == 0 {
+		// Zero pod rows hides the whole point of the command; treat the unset
+		// int as the default rather than as a request for nothing.
+		limit = ShowAllPods
+	}
+
+	return RenderOne(out, format, view, func(w io.Writer) error {
+		return workloadText(w, view, limit)
+	})
+}
+
+func workloadText(out io.Writer, view *workload.DescribeView, limit int) error {
+	if err := writeHeader(out, view); err != nil {
+		return err
+	}
+	if err := writeTree(out, view, limit); err != nil {
+		return err
+	}
+	if err := writeStatus(out, view); err != nil {
+		return err
+	}
+	return writeResources(out, view)
+}
+
+func writeHeader(out io.Writer, view *workload.DescribeView) error {
+	fields := []string{
+		fmt.Sprintf("%s/%s", view.Kind, view.Name),
+		"namespace: " + orNone(view.Namespace),
+		fmt.Sprintf("definition: %s (%s)", view.Definition, view.Origin),
+	}
+	if !view.FileMode {
+		fields = append(fields, "age: "+age(time.Now(), view.CreatedAt))
+	}
+
+	if _, err := fmt.Fprintln(out, strings.Join(fields, "   ")); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	if view.FileMode {
+		if _, err := fmt.Fprintln(out, fileModeNote); err != nil {
+			return fmt.Errorf("write header: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeTree renders the component hierarchy, one row per component and one per
+// pod, through a tab writer so every column lines up across both row kinds.
+func writeTree(out io.Writer, view *workload.DescribeView, limit int) error {
+	if len(view.Components) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return fmt.Errorf("write tree: %w", err)
+	}
+
+	writer := printers.GetNewTabWriter(out)
+	writeComponents(writer, view.Components, "", limit)
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write tree: %w", err)
+	}
+	return nil
+}
+
+func writeComponents(out io.Writer, components []workload.ComponentView, prefix string, limit int) {
+	for i, component := range components {
+		last := i == len(components)-1
+		fmt.Fprintln(out, strings.Join([]string{
+			prefix + branch(last) + component.Name,
+			readiness(component.Replicas),
+			resourceCell(component.Resources),
+			strings.Join(component.Nodes, ","),
+		}, "\t"))
+
+		childPrefix := prefix + indent(last)
+		writePods(out, component.Pods, childPrefix, limit)
+		writeComponents(out, component.Children, childPrefix, limit)
+	}
+}
+
+func writePods(out io.Writer, pods []workload.PodView, prefix string, limit int) {
+	shown, hidden, unhealthy := limitPods(pods, limit)
+
+	for i, pod := range shown {
+		// The truncation line is the last row under this component, so a shown
+		// pod is only "last" when nothing follows it.
+		last := i == len(shown)-1 && hidden == 0
+		fmt.Fprintln(out, strings.Join([]string{
+			prefix + branch(last) + pod.Name,
+			podStatus(pod),
+			resourceCell(pod.Resources),
+			orNone(deref(pod.Node)),
+		}, "\t"))
+	}
+
+	if hidden > 0 {
+		// No tabs: the note is prose, and a cell of it would widen the name
+		// column for every row in the tree.
+		fmt.Fprintf(out, "%s%s... and %d more (%d unhealthy shown)\n",
+			prefix, branch(true), hidden, unhealthy)
+	}
+}
+
+// limitPods applies --pod-limit. Unhealthy pods sort first, so truncation can
+// never hide the failing pod the reader is looking for.
+func limitPods(pods []workload.PodView, limit int) (shown []workload.PodView, hidden, unhealthy int) {
+	if limit < 0 || len(pods) <= limit {
+		return pods, 0, 0
+	}
+
+	ordered := slices.Clone(pods)
+	slices.SortStableFunc(ordered, func(a, b workload.PodView) int {
+		switch {
+		case a.Ready == b.Ready:
+			return 0
+		case a.Ready:
+			return 1
+		default:
+			return -1
+		}
+	})
+
+	shown = ordered[:limit]
+	for _, pod := range shown {
+		if !pod.Ready {
+			unhealthy++
+		}
+	}
+	return shown, len(ordered) - limit, unhealthy
+}
+
+func writeStatus(out io.Writer, view *workload.DescribeView) error {
+	if view.FileMode {
+		return nil
+	}
+	// Several status mappings can match at once, and hiding one would misreport
+	// the workload, so every matched phase is named.
+	if _, err := fmt.Fprintf(out, "\nPhase: %s\n", strings.Join(view.Phases, ",")); err != nil {
+		return fmt.Errorf("write status: %w", err)
+	}
+	return nil
+}
+
+// writeResources breaks the request down per component, with the workload total
+// last, so a reader can see which component accounts for the bill.
+func writeResources(out io.Writer, view *workload.DescribeView) error {
+	if _, err := fmt.Fprintln(out, "\nResources:"); err != nil {
+		return fmt.Errorf("write resources: %w", err)
+	}
+
+	writer := printers.GetNewTabWriter(out)
+	fmt.Fprintln(writer, "COMPONENT\tREPLICAS\tGPU\tCPU\tMEMORY")
+
+	var replicas int32
+	for _, component := range leaves(view.Components) {
+		replicas += component.Replicas.Desired
+		writeResourceRow(writer, component.Name, component.Replicas.Desired, component.Resources)
+	}
+	writeResourceRow(writer, "TOTAL", replicas, view.Resources)
+
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write resources: %w", err)
+	}
+	return nil
+}
+
+func writeResourceRow(out io.Writer, name string, replicas int32, request workload.Resources) {
+	fmt.Fprintf(out, "%s\t%d\t%d\t%s\t%s\n",
+		name, replicas, request.GPUs, cpu(request.CPUMillis), memory(request.MemoryBytes))
+}
+
+// leaves flattens the tree to the components that carry pods. A grouping
+// component only repeats the sum of the rows below it.
+func leaves(components []workload.ComponentView) []workload.ComponentView {
+	var out []workload.ComponentView
+	for _, component := range components {
+		if len(component.Children) == 0 {
+			out = append(out, component)
+			continue
+		}
+		out = append(out, leaves(component.Children)...)
+	}
+	return out
+}
+
+func branch(last bool) string {
+	if last {
+		return "`-- "
+	}
+	return "|-- "
+}
+
+func indent(last bool) string {
+	if last {
+		return "    "
+	}
+	return "|   "
+}
+
+func readiness(replicas workload.Replicas) string {
+	return fmt.Sprintf("%d/%d ready", replicas.Ready, replicas.Desired)
+}
+
+func podStatus(pod workload.PodView) string {
+	if pod.Reason == "" {
+		return pod.Phase
+	}
+	return fmt.Sprintf("%s (%s)", pod.Phase, pod.Reason)
+}
+
+func resourceCell(request workload.Resources) string {
+	if request.GPUs == 0 {
+		return ""
+	}
+	return fmt.Sprintf("gpu: %d", request.GPUs)
+}
+
+// cpu renders millicores the way a request is written, so 20000m reads as 20.
+func cpu(millis int64) string {
+	return resource.NewMilliQuantity(millis, resource.DecimalSI).String()
+}
+
+// memory prefers binary units and falls back to decimal, so a request written
+// as 70M renders as 70M rather than as a raw byte count.
+func memory(bytes int64) string {
+	if binary := resource.NewQuantity(bytes, resource.BinarySI).String(); strings.HasSuffix(binary, "i") {
+		return binary
+	}
+	return resource.NewQuantity(bytes, resource.DecimalSI).String()
+}
+
+func deref(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func orNone(value string) string {
+	if value == "" {
+		return "<none>"
+	}
+	return value
+}

--- a/cli/pkg/generator/describe_test.go
+++ b/cli/pkg/generator/describe_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package generator
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
+	"github.com/run-ai/karta/cli/pkg/workload"
+)
+
+// decodeYAML reads yaml through json, so one struct tag set serves both.
+func decodeYAML(data []byte, into any) error { return yaml.Unmarshal(data, into) }
+
+// detailView is the worked example from the describe design: a PyTorchJob with
+// a ready master and a worker whose last replica cannot be scheduled.
+func detailView() *workload.DescribeView {
+	return &workload.DescribeView{
+		Name:       "llama-finetune",
+		Namespace:  "ml-team",
+		Kind:       "PyTorchJob",
+		CreatedAt:  time.Now().Add(-2 * time.Hour),
+		Definition: "kubeflow-org-pytorchjob-v1",
+		Origin:     "catalog",
+		Phases:     []string{"Running"},
+		Resources:  workload.Resources{GPUs: 33, CPUMillis: 20000, MemoryBytes: 80 << 30},
+		Components: []workload.ComponentView{
+			{
+				Name:      "master",
+				Replicas:  workload.Replicas{Desired: 1, Current: 1, Ready: 1},
+				Resources: workload.Resources{GPUs: 1, CPUMillis: 4000, MemoryBytes: 16 << 30},
+				Nodes:     []string{"node-01"},
+				Pods: []workload.PodView{
+					{Name: "master-0", Phase: "Running", Ready: true, Node: ptr.To("node-01")},
+				},
+			},
+			{
+				Name:      "worker",
+				Replicas:  workload.Replicas{Desired: 4, Current: 4, Ready: 3},
+				Resources: workload.Resources{GPUs: 32, CPUMillis: 16000, MemoryBytes: 64 << 30},
+				Nodes:     []string{"node-02", "node-03"},
+				Pods: []workload.PodView{
+					{Name: "worker-0", Phase: "Running", Ready: true, Node: ptr.To("node-02")},
+					{Name: "worker-1", Phase: "Running", Ready: true, Node: ptr.To("node-02")},
+					{Name: "worker-2", Phase: "Running", Ready: true, Node: ptr.To("node-03")},
+					{Name: "worker-3", Phase: "Pending", Reason: "Unschedulable"},
+				},
+			},
+		},
+	}
+}
+
+func renderWorkload(view *workload.DescribeView, opts DescribeOptions) string {
+	GinkgoHelper()
+	var out bytes.Buffer
+	Expect(RenderWorkload(&out, view, opts)).To(Succeed())
+	return out.String()
+}
+
+// treeLines returns the rows between the header and the status section.
+func treeLines(out string) []string {
+	GinkgoHelper()
+	_, rest, found := strings.Cut(out, "\n")
+	Expect(found).To(BeTrue())
+	tree, _, found := strings.Cut(strings.TrimLeft(rest, "\n"), "\nPhase:")
+	Expect(found).To(BeTrue())
+	return strings.Split(strings.TrimRight(tree, "\n"), "\n")
+}
+
+var _ = Describe("RenderWorkload", func() {
+	Context("the human rendering", func() {
+		It("names the workload, its definition and its origin in the header", func() {
+			header := strings.SplitN(renderWorkload(detailView(), DescribeOptions{}), "\n", 2)[0]
+
+			Expect(header).To(ContainSubstring("PyTorchJob/llama-finetune"))
+			Expect(header).To(ContainSubstring("namespace: ml-team"))
+			Expect(header).To(ContainSubstring("definition: kubeflow-org-pytorchjob-v1 (catalog)"))
+			Expect(header).To(ContainSubstring("age: "))
+		})
+
+		It("renders every pod by default, the way kubectl-tree renders every descendant", func() {
+			lines := treeLines(renderWorkload(detailView(), DescribeOptions{}))
+
+			Expect(lines).To(HaveLen(7), "two components and five pods")
+			Expect(lines[0]).To(HavePrefix("|-- master"))
+			Expect(lines[1]).To(HavePrefix("|   `-- master-0"))
+			Expect(lines[2]).To(HavePrefix("`-- worker"))
+			Expect(lines[6]).To(HavePrefix("    `-- worker-3"))
+		})
+
+		It("reads ready counts against the desired scale, not against the pods that exist", func() {
+			Expect(treeLines(renderWorkload(detailView(), DescribeOptions{}))[2]).
+				To(ContainSubstring("3/4 ready"))
+		})
+
+		It("names why a pod is not running", func() {
+			Expect(renderWorkload(detailView(), DescribeOptions{})).
+				To(ContainSubstring("Pending (Unschedulable)"))
+		})
+
+		It("marks an unscheduled pod rather than leaving the node column blank", func() {
+			Expect(treeLines(renderWorkload(detailView(), DescribeOptions{}))[6]).
+				To(HaveSuffix("<none>"))
+		})
+
+		It("breaks resources down per component with the workload total last", func() {
+			_, resources, found := strings.Cut(renderWorkload(detailView(), DescribeOptions{}), "Resources:\n")
+			Expect(found).To(BeTrue())
+
+			rows := cells(resources)
+			Expect(rows[0]).To(Equal([]string{"COMPONENT", "REPLICAS", "GPU", "CPU", "MEMORY"}))
+			Expect(rows[1]).To(Equal([]string{"master", "1", "1", "4", "16Gi"}))
+			Expect(rows[2]).To(Equal([]string{"worker", "4", "32", "16", "64Gi"}))
+			Expect(rows[3]).To(Equal([]string{"TOTAL", "5", "33", "20", "80Gi"}))
+		})
+
+		// A request written as 70M is not a binary multiple, so binary units
+		// alone would render it as a raw byte count.
+		It("renders a decimal memory request in decimal units", func() {
+			view := detailView()
+			view.Resources = workload.Resources{MemoryBytes: 70_000_000}
+			view.Components = []workload.ComponentView{{
+				Name:      "loop",
+				Replicas:  workload.Replicas{Desired: 1},
+				Resources: workload.Resources{MemoryBytes: 70_000_000},
+			}}
+
+			_, resources, found := strings.Cut(renderWorkload(view, DescribeOptions{}), "Resources:\n")
+			Expect(found).To(BeTrue())
+			Expect(cells(resources)[1]).To(Equal([]string{"loop", "1", "0", "0", "70M"}))
+		})
+
+		It("names every matched phase, since status mappings are not exclusive", func() {
+			view := detailView()
+			view.Phases = []string{"Running", "Degraded"}
+
+			Expect(renderWorkload(view, DescribeOptions{})).To(ContainSubstring("Phase: Running,Degraded"))
+		})
+
+		Context("file mode", func() {
+			It("says the status is absent rather than rendering an empty one", func() {
+				view := detailView()
+				view.FileMode = true
+
+				out := renderWorkload(view, DescribeOptions{})
+				Expect(out).To(ContainSubstring("(file mode: no live status)"))
+				Expect(out).NotTo(ContainSubstring("Phase:"))
+				Expect(out).NotTo(ContainSubstring("age:"), "a manifest has no age")
+			})
+		})
+	})
+
+	Context("--pod-limit", func() {
+		It("shows the unhealthy pod first, so truncation cannot hide it", func() {
+			lines := treeLines(renderWorkload(detailView(), DescribeOptions{PodLimit: 2}))
+
+			Expect(lines[3]).To(ContainSubstring("worker-3"), "the first worker row is the failing one")
+			Expect(lines[5]).To(ContainSubstring("... and 2 more (1 unhealthy shown)"))
+		})
+
+		It("reports what it hid rather than truncating silently", func() {
+			Expect(renderWorkload(detailView(), DescribeOptions{PodLimit: 1})).
+				To(ContainSubstring("... and 3 more (1 unhealthy shown)"))
+		})
+
+		It("leaves a component alone when its pods fit", func() {
+			Expect(renderWorkload(detailView(), DescribeOptions{PodLimit: 4})).
+				NotTo(ContainSubstring("and 0 more"))
+		})
+
+		// The zero value is what an unset int carries, and no pod rows at all
+		// would hide the point of the command.
+		It("treats an unset limit as showing every pod", func() {
+			Expect(treeLines(renderWorkload(detailView(), DescribeOptions{}))).
+				To(Equal(treeLines(renderWorkload(detailView(), DescribeOptions{PodLimit: ShowAllPods}))))
+		})
+	})
+
+	Context("machine output", func() {
+		// An items/count envelope would say nothing about a single workload, and
+		// would cost every consumer an items[0] hop.
+		It("emits the view itself, not a list of one", func() {
+			var out bytes.Buffer
+			Expect(RenderWorkload(&out, detailView(), DescribeOptions{Output: OutputJSON})).To(Succeed())
+
+			var decoded workload.DescribeView
+			Expect(json.Unmarshal(out.Bytes(), &decoded)).To(Succeed())
+			Expect(decoded.Name).To(Equal("llama-finetune"))
+			Expect(decoded.Components).To(HaveLen(2))
+		})
+
+		// A consumer that has to re-parse "3/4" breaks silently when the human
+		// rendering changes.
+		It("carries counts and resources as numbers, never as display strings", func() {
+			var out bytes.Buffer
+			Expect(RenderWorkload(&out, detailView(), DescribeOptions{Output: OutputJSON})).To(Succeed())
+
+			var decoded map[string]any
+			Expect(json.Unmarshal(out.Bytes(), &decoded)).To(Succeed())
+			Expect(decoded["resources"]).To(HaveKeyWithValue("gpus", BeNumerically("==", 33)))
+
+			worker := decoded["components"].([]any)[1].(map[string]any)
+			Expect(worker["replicas"]).To(HaveKeyWithValue("ready", BeNumerically("==", 3)))
+			Expect(worker["replicas"]).To(HaveKeyWithValue("desired", BeNumerically("==", 4)))
+		})
+
+		It("reports an unscheduled pod as a null node", func() {
+			var out bytes.Buffer
+			Expect(RenderWorkload(&out, detailView(), DescribeOptions{Output: OutputJSON})).To(Succeed())
+
+			Expect(out.String()).To(ContainSubstring(`"node": null`))
+		})
+
+		It("agrees with json on the same view", func() {
+			view := detailView()
+
+			var asJSON, asYAML bytes.Buffer
+			Expect(RenderWorkload(&asJSON, view, DescribeOptions{Output: OutputJSON})).To(Succeed())
+			Expect(RenderWorkload(&asYAML, view, DescribeOptions{Output: OutputYAML})).To(Succeed())
+
+			var fromJSON, fromYAML workload.DescribeView
+			Expect(json.Unmarshal(asJSON.Bytes(), &fromJSON)).To(Succeed())
+			Expect(decodeYAML(asYAML.Bytes(), &fromYAML)).To(Succeed())
+			Expect(fromYAML).To(Equal(fromJSON))
+		})
+	})
+})

--- a/cli/pkg/generator/describe_test.go
+++ b/cli/pkg/generator/describe_test.go
@@ -156,6 +156,17 @@ var _ = Describe("RenderWorkload", func() {
 				Expect(out).NotTo(ContainSubstring("Phase:"))
 				Expect(out).NotTo(ContainSubstring("age:"), "a manifest has no age")
 			})
+
+			// "0/4 ready" would read as four pods that failed to start, where
+			// the truth is that there are no pods to be ready yet.
+			It("reports the desired scale rather than a readiness of zero", func() {
+				view := detailView()
+				view.FileMode = true
+
+				out := renderWorkload(view, DescribeOptions{})
+				Expect(out).To(ContainSubstring("replicas: 4"))
+				Expect(out).NotTo(ContainSubstring("ready"))
+			})
 		})
 	})
 

--- a/cli/pkg/generator/render.go
+++ b/cli/pkg/generator/render.go
@@ -31,20 +31,30 @@ func newList[T any](items []T) list[T] {
 
 // Render writes items in the machine formats and hands the human ones to table.
 func Render[T any](out io.Writer, format Output, items []T, table func(io.Writer) error) error {
+	return render(out, format, newList(items), table)
+}
+
+// RenderOne is Render for a single subject, emitted bare: an envelope would say
+// nothing there and cost a consumer an items[0] hop.
+func RenderOne[T any](out io.Writer, format Output, item T, human func(io.Writer) error) error {
+	return render(out, format, item, human)
+}
+
+func render(out io.Writer, format Output, value any, human func(io.Writer) error) error {
 	switch format {
 	case OutputTable, OutputWide:
-		return table(out)
+		return human(out)
 
 	case OutputJSON:
 		encoder := json.NewEncoder(out)
 		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(newList(items)); err != nil {
+		if err := encoder.Encode(value); err != nil {
 			return fmt.Errorf("encode as json: %w", err)
 		}
 		return nil
 
 	case OutputYAML:
-		data, err := yaml.Marshal(newList(items))
+		data, err := yaml.Marshal(value)
 		if err != nil {
 			return fmt.Errorf("encode as yaml: %w", err)
 		}

--- a/cli/pkg/workload/describe.go
+++ b/cli/pkg/workload/describe.go
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package workload
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/pkg/api/runai/v1alpha1"
+	"github.com/run-ai/karta/pkg/resource"
+	"github.com/run-ai/karta/pkg/tree"
+)
+
+// gpuResourceName is the extended resource a GPU request is declared under.
+const gpuResourceName = corev1.ResourceName("nvidia.com/gpu")
+
+// DescribeView is one workload in full. Every describe rendering draws from this
+// one struct, so the human and the machine output cannot drift apart.
+type DescribeView struct {
+	Name       string    `json:"name"`
+	Namespace  string    `json:"namespace"`
+	Kind       string    `json:"kind"`
+	APIVersion string    `json:"apiVersion"`
+	CreatedAt  time.Time `json:"createdAt"`
+	Definition string    `json:"definition"`
+	Origin     string    `json:"origin"`
+	Phases     []string  `json:"phases"`
+	// FileMode marks a view built from a manifest: the structure and desired
+	// scale are real, everything live is absent rather than zero.
+	FileMode bool `json:"fileMode"`
+	// Resources is the whole workload's request, the sum over Components.
+	Resources  Resources       `json:"resources"`
+	Components []ComponentView `json:"components"`
+}
+
+// ComponentView is one component, or one instance of a multi-instance
+// component, with the pods that were attributed to it.
+type ComponentView struct {
+	Name string `json:"name"`
+	// Kind is empty for a logical grouping component, which owns no objects.
+	Kind      string    `json:"kind,omitempty"`
+	Replicas  Replicas  `json:"replicas"`
+	Resources Resources `json:"resources"`
+	// Nodes are the distinct nodes this component's pods landed on.
+	Nodes    []string        `json:"nodes,omitempty"`
+	Pods     []PodView       `json:"pods,omitempty"`
+	Children []ComponentView `json:"children,omitempty"`
+}
+
+// Replicas counts a component three ways: what the spec asks for, how many
+// pods exist, and how many of those are ready.
+type Replicas struct {
+	Desired int32 `json:"desired"`
+	Current int32 `json:"current"`
+	Ready   int32 `json:"ready"`
+}
+
+// PodView is one live pod attributed to a component.
+type PodView struct {
+	Name  string `json:"name"`
+	Phase string `json:"phase"`
+	Ready bool   `json:"ready"`
+	// Node is null for a pod that has not been scheduled.
+	Node *string `json:"node"`
+	// Reason explains a pod that is not running, e.g. "Unschedulable".
+	Reason    string    `json:"reason,omitempty"`
+	Resources Resources `json:"resources"`
+}
+
+// Resources is a request total. CPU is in millicores and memory in bytes, so
+// every field is an integer a consumer can sum without unit handling.
+type Resources struct {
+	GPUs        int64 `json:"gpus"`
+	CPUMillis   int64 `json:"cpuMillis"`
+	MemoryBytes int64 `json:"memoryBytes"`
+}
+
+func (r *Resources) add(other Resources) {
+	r.GPUs += other.GPUs
+	r.CPUMillis += other.CPUMillis
+	r.MemoryBytes += other.MemoryBytes
+}
+
+func (r Resources) scaled(replicas int32) Resources {
+	return Resources{
+		GPUs:        r.GPUs * int64(replicas),
+		CPUMillis:   r.CPUMillis * int64(replicas),
+		MemoryBytes: r.MemoryBytes * int64(replicas),
+	}
+}
+
+// ResolveDescribe reads obj through def, placing pods on the component and
+// instance its selectors name. pods must already be scoped; nil is file mode.
+func ResolveDescribe(
+	ctx context.Context, obj *unstructured.Unstructured, def definitions.Definition, pods []corev1.Pod,
+) (*DescribeView, error) {
+	factory := resource.NewComponentFactoryFromObject(def.Karta, obj)
+
+	workloadTree, err := tree.Build(ctx, factory)
+	if err != nil {
+		return nil, fmt.Errorf("build tree: %w", err)
+	}
+
+	view := &DescribeView{
+		Name:       obj.GetName(),
+		Namespace:  obj.GetNamespace(),
+		Kind:       obj.GetKind(),
+		APIVersion: obj.GetAPIVersion(),
+		CreatedAt:  obj.GetCreationTimestamp().Time,
+		Definition: def.Karta.Name,
+		Origin:     string(def.Origin),
+		Phases:     phases(workloadTree),
+		Components: []ComponentView{},
+	}
+
+	defs := indexComponentDefs(def.Karta)
+
+	// tree.Build drops the root, but Deployment, StatefulSet, Job and Pod carry
+	// their pod template on it, so the root itself can be pod-bearing.
+	root, err := factory.GetRootComponent()
+	if err != nil {
+		return nil, fmt.Errorf("get root component: %w", err)
+	}
+	if root.HasPodDefinition() {
+		instances, err := rootInstances(ctx, root)
+		if err != nil {
+			return nil, err
+		}
+		component, err := buildComponent(ctx, root.Name(), kindOf(root.Kind()), defs[root.Name()], instances, pods, defs)
+		if err != nil {
+			return nil, fmt.Errorf("build root component: %w", err)
+		}
+		view.Components = appendComponent(view.Components, component, true)
+	}
+
+	for _, node := range workloadTree.Children {
+		component, err := buildNode(ctx, node, defs, pods)
+		if err != nil {
+			return nil, fmt.Errorf("build component %q: %w", node.Name, err)
+		}
+		view.Components = appendComponent(view.Components, component, node.HasPodDefinition)
+	}
+
+	for _, component := range view.Components {
+		view.Resources.add(component.Resources)
+	}
+	return view, nil
+}
+
+// rootInstances rebuilds the instance nodes tree.Build discards for the root,
+// so a root-hosted pod template goes through the same path as any component.
+func rootInstances(ctx context.Context, root *resource.Component) ([]tree.InstanceNode, error) {
+	extracted, err := root.GetExtractedInstances(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("extract root instances: %w", err)
+	}
+
+	instances := make([]tree.InstanceNode, 0, len(extracted))
+	for _, id := range slices.Sorted(maps.Keys(extracted)) {
+		instance := extracted[id]
+		node := tree.InstanceNode{Scale: instance.Scale, ExtractedInstance: &instance}
+		if id != "" {
+			node.InstanceKey = &id
+		}
+		instances = append(instances, node)
+	}
+	return instances, nil
+}
+
+func indexComponentDefs(karta *v1alpha1.Karta) map[string]v1alpha1.ComponentDefinition {
+	defs := make(map[string]v1alpha1.ComponentDefinition, len(karta.Spec.StructureDefinition.ChildComponents)+1)
+	defs[karta.Spec.StructureDefinition.RootComponent.Name] = karta.Spec.StructureDefinition.RootComponent
+	for _, child := range karta.Spec.StructureDefinition.ChildComponents {
+		defs[child.Name] = child
+	}
+	return defs
+}
+
+// buildNode renders one ComponentNode: a grouping component only recurses, a
+// pod-bearing one claims the pods its ComponentTypeSelector accepts.
+func buildNode(
+	ctx context.Context, node tree.ComponentNode, defs map[string]v1alpha1.ComponentDefinition, pods []corev1.Pod,
+) (ComponentView, error) {
+	kind := kindOf(node.Kind)
+	def := defs[node.Name]
+
+	claimed := pods
+	if node.HasPodDefinition {
+		var err error
+		if claimed, err = matchComponentType(ctx, def.PodSelector, pods); err != nil {
+			return ComponentView{}, fmt.Errorf("match pods to component %q: %w", node.Name, err)
+		}
+	}
+
+	if !isMultiInstance(node.Instances) {
+		if node.HasPodDefinition {
+			return buildComponent(ctx, node.Name, kind, def, node.Instances, claimed, defs)
+		}
+		return buildGrouping(ctx, node.Name, kind, node.Instances, claimed, defs)
+	}
+
+	// A grouping component takes this path too: it holds no pods itself, but its
+	// ReplicaSelector still decides which pods its descendants may see.
+	parent := ComponentView{Name: node.Name, Kind: kind}
+	for _, instance := range node.Instances {
+		scoped, err := filterByInstance(ctx, def.PodSelector, instance, claimed)
+		if err != nil {
+			return ComponentView{}, fmt.Errorf("match pods to instance of %q: %w", node.Name, err)
+		}
+
+		label := instanceLabel(node.Name, instance)
+		one := []tree.InstanceNode{instance}
+
+		var child ComponentView
+		if node.HasPodDefinition {
+			child, err = buildComponent(ctx, label, kind, def, one, scoped, defs)
+		} else {
+			child, err = buildGrouping(ctx, label, kind, one, scoped, defs)
+		}
+		if err != nil {
+			return ComponentView{}, err
+		}
+
+		parent.Children = appendComponent(parent.Children, child, node.HasPodDefinition)
+		parent.aggregate(child)
+	}
+	return parent, nil
+}
+
+// buildGrouping renders a component that owns no pods of its own: it carries
+// only its descendants and their roll-up.
+func buildGrouping(
+	ctx context.Context,
+	name, kind string,
+	instances []tree.InstanceNode,
+	pods []corev1.Pod,
+	defs map[string]v1alpha1.ComponentDefinition,
+) (ComponentView, error) {
+	component := ComponentView{Name: name, Kind: kind}
+	for _, instance := range instances {
+		for _, node := range instance.Children {
+			child, err := buildNode(ctx, node, defs, pods)
+			if err != nil {
+				return ComponentView{}, err
+			}
+			component.Children = appendComponent(component.Children, child, node.HasPodDefinition)
+			component.aggregate(child)
+		}
+	}
+	return component, nil
+}
+
+// buildComponent renders a pod-bearing component from the pods already matched
+// to it, plus the desired scale and per-replica request read off its spec.
+func buildComponent(
+	ctx context.Context,
+	name, kind string,
+	def v1alpha1.ComponentDefinition,
+	instances []tree.InstanceNode,
+	pods []corev1.Pod,
+	defs map[string]v1alpha1.ComponentDefinition,
+) (ComponentView, error) {
+	component := ComponentView{Name: name, Kind: kind}
+	component.attach(pods)
+
+	for _, instance := range instances {
+		replicas := replicasOf(instance.Scale)
+		component.Replicas.Desired += replicas
+		if instance.ExtractedInstance != nil {
+			component.Resources.add(requestOf(*instance.ExtractedInstance).scaled(replicas))
+		}
+
+		for _, node := range instance.Children {
+			child, err := buildNode(ctx, node, defs, pods)
+			if err != nil {
+				return ComponentView{}, err
+			}
+			component.Children = appendComponent(component.Children, child, node.HasPodDefinition)
+			// Only the totals roll up: a child's own pods are its own rows.
+			component.Resources.add(child.Resources)
+			component.Nodes = mergeNodes(component.Nodes, child.Nodes)
+		}
+	}
+	return component, nil
+}
+
+// attach records the pods matched to a component: one row each, plus the counts
+// and nodes derived from them.
+func (c *ComponentView) attach(pods []corev1.Pod) {
+	for i := range pods {
+		pod := &pods[i]
+		ready := isPodReady(pod)
+		c.Replicas.Current++
+		if ready {
+			c.Replicas.Ready++
+		}
+
+		row := PodView{
+			Name:      pod.Name,
+			Phase:     string(pod.Status.Phase),
+			Ready:     ready,
+			Resources: podRequest(pod.Spec),
+		}
+		if node := pod.Spec.NodeName; node != "" {
+			row.Node = &node
+			c.Nodes = mergeNodes(c.Nodes, []string{node})
+		}
+		if !ready {
+			row.Reason = podReason(pod.Status)
+		}
+		c.Pods = append(c.Pods, row)
+	}
+	slices.SortFunc(c.Pods, func(a, b PodView) int { return strings.Compare(a.Name, b.Name) })
+}
+
+// appendComponent drops plumbing the workload never populated, such as a
+// Deployment's ReplicaSet. A pod-bearing component stays even at zero replicas.
+func appendComponent(components []ComponentView, component ComponentView, podBearing bool) []ComponentView {
+	if !podBearing && component.empty() {
+		return components
+	}
+	return append(components, component)
+}
+
+func (c ComponentView) empty() bool {
+	return len(c.Pods) == 0 && len(c.Children) == 0 &&
+		c.Replicas == Replicas{} && c.Resources == Resources{}
+}
+
+// aggregate folds a child's totals into a parent that wraps it.
+func (c *ComponentView) aggregate(child ComponentView) {
+	c.Replicas.Desired += child.Replicas.Desired
+	c.Replicas.Current += child.Replicas.Current
+	c.Replicas.Ready += child.Replicas.Ready
+	c.Resources.add(child.Resources)
+	c.Nodes = mergeNodes(c.Nodes, child.Nodes)
+}
+
+// podReason explains a pod that is not ready. The scheduler's reason is the
+// short form a tree row has space for; a failure falls back to its own.
+func podReason(status corev1.PodStatus) string {
+	for _, condition := range status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse {
+			return condition.Reason
+		}
+	}
+	return status.Reason
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func mergeNodes(existing, add []string) []string {
+	merged := append(slices.Clone(existing), add...)
+	slices.Sort(merged)
+	return slices.Compact(merged)
+}
+
+// isMultiInstance reports a component whose instances are told apart by an
+// instance key or a replica key, and so render as one row each.
+func isMultiInstance(instances []tree.InstanceNode) bool {
+	if len(instances) <= 1 {
+		return false
+	}
+	for _, instance := range instances {
+		if instance.InstanceKey != nil || instance.ReplicaKey != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func instanceLabel(componentName string, instance tree.InstanceNode) string {
+	switch {
+	case instance.InstanceKey != nil:
+		return *instance.InstanceKey
+	case instance.ReplicaKey != nil:
+		return fmt.Sprintf("%s[%s]", componentName, *instance.ReplicaKey)
+	default:
+		return componentName
+	}
+}
+
+// matchComponentType keeps the pods a component's ComponentTypeSelector accepts.
+// A nil selector claims every candidate, right for a root-only workload.
+func matchComponentType(ctx context.Context, selector *v1alpha1.PodSelector, pods []corev1.Pod) ([]corev1.Pod, error) {
+	if selector == nil || selector.ComponentTypeSelector == nil {
+		return pods, nil
+	}
+	var matched []corev1.Pod
+	for i := range pods {
+		ok, err := resource.NewPodQuerier(&pods[i]).MatchesComponentType(ctx, selector.ComponentTypeSelector)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			matched = append(matched, pods[i])
+		}
+	}
+	return matched, nil
+}
+
+// filterByInstance narrows a component's pods to one instance, by instance id or
+// replica key. With neither, every pod reaches every instance.
+func filterByInstance(
+	ctx context.Context, selector *v1alpha1.PodSelector, instance tree.InstanceNode, pods []corev1.Pod,
+) ([]corev1.Pod, error) {
+	if selector == nil {
+		return pods, nil
+	}
+	var matched []corev1.Pod
+	for i := range pods {
+		querier := resource.NewPodQuerier(&pods[i])
+		if instance.InstanceKey != nil {
+			id, found, err := querier.ExtractInstanceId(ctx, selector.ComponentInstanceSelector)
+			if err != nil {
+				return nil, err
+			}
+			if !found || id != *instance.InstanceKey {
+				continue
+			}
+		}
+		if instance.ReplicaKey != nil {
+			key, found, err := querier.ExtractReplicaKey(ctx, selector.ReplicaSelector)
+			if err != nil {
+				return nil, err
+			}
+			if !found || key != *instance.ReplicaKey {
+				continue
+			}
+		}
+		matched = append(matched, pods[i])
+	}
+	return matched, nil
+}
+
+// replicasOf reports the desired replica count. A component declaring only a
+// scaling envelope falls back to its minimum, then to one.
+func replicasOf(scale *resource.Scale) int32 {
+	switch {
+	case scale == nil:
+		return 1
+	case scale.Replicas != nil:
+		return *scale.Replicas
+	case scale.MinReplicas != nil:
+		return *scale.MinReplicas
+	default:
+		return 1
+	}
+}
+
+// requestOf sums what one replica of an instance requests. The spec shapes are
+// mutually exclusive, so a definition naming several counts only the first.
+func requestOf(instance resource.ExtractedInstance) Resources {
+	switch {
+	case instance.PodTemplateSpec != nil:
+		return podRequest(instance.PodTemplateSpec.Spec)
+	case instance.PodSpec != nil:
+		return podRequest(*instance.PodSpec)
+	case instance.FragmentedPodSpec != nil:
+		return fragmentedRequest(*instance.FragmentedPodSpec)
+	default:
+		return Resources{}
+	}
+}
+
+func fragmentedRequest(spec resource.FragmentedPodSpec) Resources {
+	switch {
+	case len(spec.Containers) > 0:
+		return sumContainers(spec.Containers)
+	case spec.Container != nil:
+		return sumContainers([]corev1.Container{*spec.Container})
+	case spec.Resources != nil:
+		return requirementsOf(*spec.Resources)
+	default:
+		return Resources{}
+	}
+}
+
+// podRequest mirrors the effective pod request Kubernetes schedules against:
+// max(largest init container, regular containers plus sidecars).
+func podRequest(spec corev1.PodSpec) Resources {
+	running := sumContainers(spec.Containers)
+
+	var largestInit Resources
+	for _, container := range spec.InitContainers {
+		request := requirementsOf(container.Resources)
+		// A sidecar never exits, so it accumulates rather than peaking.
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			running.add(request)
+			continue
+		}
+		largestInit = Resources{
+			GPUs:        max(largestInit.GPUs, request.GPUs),
+			CPUMillis:   max(largestInit.CPUMillis, request.CPUMillis),
+			MemoryBytes: max(largestInit.MemoryBytes, request.MemoryBytes),
+		}
+	}
+
+	return Resources{
+		GPUs:        max(largestInit.GPUs, running.GPUs),
+		CPUMillis:   max(largestInit.CPUMillis, running.CPUMillis),
+		MemoryBytes: max(largestInit.MemoryBytes, running.MemoryBytes),
+	}
+}
+
+func sumContainers(containers []corev1.Container) Resources {
+	var total Resources
+	for _, container := range containers {
+		total.add(requirementsOf(container.Resources))
+	}
+	return total
+}
+
+// requirementsOf falls back to limits: an extended resource such as a GPU is
+// often declared there only, and a limit without a request implies it.
+func requirementsOf(requirements corev1.ResourceRequirements) Resources {
+	return Resources{
+		GPUs:        quantityOf(requirements, gpuResourceName),
+		CPUMillis:   quantityOf(requirements, corev1.ResourceCPU),
+		MemoryBytes: quantityOf(requirements, corev1.ResourceMemory),
+	}
+}
+
+func quantityOf(requirements corev1.ResourceRequirements, name corev1.ResourceName) int64 {
+	quantity, ok := requirements.Requests[name]
+	if !ok {
+		if quantity, ok = requirements.Limits[name]; !ok {
+			return 0
+		}
+	}
+	if name == corev1.ResourceCPU {
+		return quantity.MilliValue()
+	}
+	return quantity.Value()
+}
+
+func kindOf(gvk *metav1.GroupVersionKind) string {
+	if gvk == nil {
+		return ""
+	}
+	return gvk.Kind
+}

--- a/cli/pkg/workload/describe_test.go
+++ b/cli/pkg/workload/describe_test.go
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 NVIDIA Corporation
+
+package workload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/run-ai/karta/cli/pkg/definitions"
+	"github.com/run-ai/karta/pkg/catalog"
+)
+
+// describeFixture resolves a manifest from testdata through the built-in
+// catalog, the way the describe command resolves a live object.
+func describeFixture(name string, pods ...corev1.Pod) *DescribeView {
+	GinkgoHelper()
+
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	Expect(err).NotTo(HaveOccurred())
+
+	obj := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal(raw, obj)).To(Succeed())
+
+	def, err := definitions.New(catalog.List(), nil).Resolve(obj.GroupVersionKind())
+	Expect(err).NotTo(HaveOccurred())
+
+	view, err := ResolveDescribe(context.Background(), obj, def, pods)
+	Expect(err).NotTo(HaveOccurred())
+	return view
+}
+
+// componentNamed finds a component at any depth, so a test does not have to
+// spell out the path through grouping components.
+func componentNamed(components []ComponentView, name string) *ComponentView {
+	for i := range components {
+		if components[i].Name == name {
+			return &components[i]
+		}
+		if found := componentNamed(components[i].Children, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// livePod builds a scheduled, ready pod carrying labels a PodSelector matches.
+func livePod(name, node string, labels map[string]string, gpus string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ml-team", Labels: labels},
+		Spec: corev1.PodSpec{
+			NodeName: node,
+			Containers: []corev1.Container{{
+				Name: "main",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{gpuResourceName: resourceQuantity(gpus)},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+// unschedulablePod is the failing pod truncation must never hide.
+func unschedulablePod(name string, labels map[string]string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ml-team", Labels: labels},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodScheduled, Status: corev1.ConditionFalse, Reason: "Unschedulable",
+			}},
+		},
+	}
+}
+
+func masterLabels() map[string]string {
+	return map[string]string{"training.kubeflow.org/replica-type": "master"}
+}
+
+func workerLabels() map[string]string {
+	return map[string]string{"training.kubeflow.org/replica-type": "worker"}
+}
+
+var _ = Describe("ResolveDescribe", func() {
+	Context("without pods, as file mode builds it", func() {
+		It("carries the structure, the desired scale and the requested resources", func() {
+			view := describeFixture("pytorchjob.yaml")
+
+			Expect(view.Name).To(Equal("llama-finetune"))
+			Expect(view.Kind).To(Equal("PyTorchJob"))
+			Expect(view.Definition).To(Equal("kubeflow-org-pytorchjob-v1"))
+			Expect(view.Origin).To(Equal(string(definitions.OriginCatalog)))
+
+			master := componentNamed(view.Components, "master")
+			Expect(master).NotTo(BeNil())
+			Expect(master.Replicas).To(Equal(Replicas{Desired: 1}))
+			Expect(master.Resources.GPUs).To(Equal(int64(1)))
+
+			worker := componentNamed(view.Components, "worker")
+			Expect(worker.Replicas).To(Equal(Replicas{Desired: 4}))
+			Expect(worker.Resources.GPUs).To(Equal(int64(32)), "8 per replica across 4 replicas")
+
+			Expect(view.Resources.GPUs).To(Equal(int64(33)))
+		})
+
+		It("leaves every live field empty rather than reporting zeroes as facts", func() {
+			view := describeFixture("pytorchjob.yaml")
+
+			for _, component := range view.Components {
+				Expect(component.Pods).To(BeEmpty())
+				Expect(component.Nodes).To(BeEmpty())
+				Expect(component.Replicas.Current).To(BeZero())
+				Expect(component.Replicas.Ready).To(BeZero())
+			}
+		})
+	})
+
+	Context("with live pods", func() {
+		It("attributes each pod to the component its selector names", func() {
+			view := describeFixture("pytorchjob.yaml",
+				livePod("llama-finetune-master-0", "node-01", masterLabels(), "1"),
+				livePod("llama-finetune-worker-1", "node-03", workerLabels(), "8"),
+				livePod("llama-finetune-worker-0", "node-02", workerLabels(), "8"),
+				livePod("llama-finetune-worker-2", "node-04", workerLabels(), "8"),
+				unschedulablePod("llama-finetune-worker-3", workerLabels()),
+			)
+
+			master := componentNamed(view.Components, "master")
+			Expect(master.Replicas).To(Equal(Replicas{Desired: 1, Current: 1, Ready: 1}))
+			Expect(master.Nodes).To(Equal([]string{"node-01"}))
+
+			worker := componentNamed(view.Components, "worker")
+			Expect(worker.Replicas).To(Equal(Replicas{Desired: 4, Current: 4, Ready: 3}))
+			Expect(worker.Nodes).To(Equal([]string{"node-02", "node-03", "node-04"}))
+
+			names := make([]string, 0, len(worker.Pods))
+			for _, pod := range worker.Pods {
+				names = append(names, pod.Name)
+			}
+			Expect(names).To(Equal([]string{
+				"llama-finetune-worker-0", "llama-finetune-worker-1",
+				"llama-finetune-worker-2", "llama-finetune-worker-3",
+			}), "pod rows are name-ordered, so a re-run reads the same")
+		})
+
+		It("reports an unscheduled pod as a null node with its reason", func() {
+			view := describeFixture("pytorchjob.yaml",
+				unschedulablePod("llama-finetune-worker-3", workerLabels()))
+
+			pending := componentNamed(view.Components, "worker").Pods[0]
+			Expect(pending.Node).To(BeNil())
+			Expect(pending.Ready).To(BeFalse())
+			Expect(pending.Phase).To(Equal("Pending"))
+			Expect(pending.Reason).To(Equal("Unschedulable"))
+		})
+
+		// The selector says which role a pod plays, so a worker pod must not
+		// land under master just because both belong to the workload.
+		It("does not claim a pod for a component whose selector rejects it", func() {
+			view := describeFixture("pytorchjob.yaml",
+				livePod("llama-finetune-worker-0", "node-02", workerLabels(), "8"))
+
+			Expect(componentNamed(view.Components, "master").Pods).To(BeEmpty())
+			Expect(componentNamed(view.Components, "worker").Pods).To(HaveLen(1))
+		})
+
+		// Requested resources come from the spec, so they do not move when a
+		// replica is missing; only the counts do.
+		It("keeps the requested totals independent of how many pods exist", func() {
+			withPods := describeFixture("pytorchjob.yaml",
+				livePod("llama-finetune-master-0", "node-01", masterLabels(), "1"))
+
+			Expect(withPods.Resources.GPUs).To(Equal(describeFixture("pytorchjob.yaml").Resources.GPUs))
+		})
+	})
+
+	// tree.Build drops the root, so a Deployment's own pod template is only
+	// visible to a consumer that asks the root component for it.
+	It("renders a workload whose pod template lives on the root", func() {
+		view := describeFixture("deployment.yaml")
+
+		Expect(view.Components).To(HaveLen(1))
+		Expect(view.Components[0].Name).To(Equal("deployment"))
+		Expect(view.Components[0].Replicas.Desired).To(Equal(int32(3)))
+		Expect(view.Resources.GPUs).To(Equal(int64(6)), "a limit counts when no request is set")
+	})
+
+	// The Deployment definition names a ReplicaSet child that carries no pods,
+	// no scale and no descendants of its own.
+	It("collapses an intermediate component that carries nothing", func() {
+		Expect(componentNamed(describeFixture("deployment.yaml").Components, "replicaset")).To(BeNil())
+	})
+
+	// Scaled to zero is a state a workload is deliberately in, not plumbing the
+	// definition named and the workload never used.
+	It("keeps a pod-bearing component scaled to zero", func() {
+		view := describeObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embed-svc
+  namespace: ml-team
+spec:
+  replicas: 0
+  template:
+    spec:
+      containers:
+        - name: server
+`))
+
+		Expect(view.Components).To(HaveLen(1))
+		Expect(view.Components[0].Name).To(Equal("deployment"))
+		Expect(view.Components[0].Replicas).To(Equal(Replicas{}))
+	})
+
+	// A multi-instance component renders one child per instance, named by its
+	// instance key rather than by the component.
+	It("splits a multi-instance component into one child per instance", func() {
+		view := describeFixture("dynamographdeployment.yaml")
+
+		frontend := componentNamed(view.Components, "Frontend")
+		Expect(frontend).NotTo(BeNil())
+		Expect(frontend.Replicas.Desired).To(Equal(int32(2)))
+		Expect(frontend.Resources.GPUs).To(Equal(int64(2)))
+
+		prefill := componentNamed(view.Components, "PrefillWorker")
+		Expect(prefill.Replicas.Desired).To(Equal(int32(4)))
+		Expect(prefill.Resources.GPUs).To(Equal(int64(32)))
+
+		Expect(view.Resources.GPUs).To(Equal(int64(34)))
+	})
+
+	It("sums cpu as millicores and memory as bytes", func() {
+		view := describeObject([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embed-svc
+  namespace: ml-team
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: server
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+`))
+
+		Expect(view.Resources.CPUMillis).To(Equal(int64(1000)))
+		Expect(view.Resources.MemoryBytes).To(Equal(int64(2 * 1024 * 1024 * 1024)))
+	})
+})
+
+// describeObject resolves an inline manifest through the built-in catalog.
+func describeObject(manifest []byte) *DescribeView {
+	GinkgoHelper()
+
+	obj := &unstructured.Unstructured{}
+	Expect(yaml.Unmarshal(manifest, obj)).To(Succeed())
+
+	def, err := definitions.New(catalog.List(), nil).Resolve(obj.GroupVersionKind())
+	Expect(err).NotTo(HaveOccurred())
+
+	view, err := ResolveDescribe(context.Background(), obj, def, nil)
+	Expect(err).NotTo(HaveOccurred())
+	return view
+}
+
+// resourceQuantity parses a quantity a fixture spells as a string.
+func resourceQuantity(value string) apiresource.Quantity {
+	GinkgoHelper()
+	quantity, err := apiresource.ParseQuantity(value)
+	Expect(err).NotTo(HaveOccurred())
+	return quantity
+}


### PR DESCRIPTION
## What does this PR do?

Adds -f, building the same view from a manifest alone with no cluster and no pods. The no-definition failure is emitted as a parseable object on stdout under a machine format, because an agent's fallback there differs from its fallback for any other failure.

Part of a seven-PR stack implementing `kli describe` (#206). Targets `feat/cli-describe-command`, which must merge first.

## Related issue(s)

Refs #206

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
