### PR TITLE
docs(cli): document the describe command in the design

### DIFF
--- a/docs/design/cli/high-level-design.md
+++ b/docs/design/cli/high-level-design.md
@@ -45,15 +45,18 @@ ml-team    │   ├─Pod/my-pipeline-prefill-0-0                  True
 ...
 ```
 
-**karta workload tree** - semantic walk:
+**karta describe** - semantic walk:
 
 ```shell
-$ karta workload tree my-pipeline
-DynamoGraphDeployment/my-pipeline [Running]
-└── service
-    ├── Frontend       (2/2 replicas)   2/2 ready
-    ├── PrefillWorker  (3/4 replicas)   3/3 ready
-    └── DecodeWorker   (4/4 replicas)   4/4 ready
+$ karta describe dynamographdeployment/my-pipeline
+DynamoGraphDeployment/my-pipeline   namespace: ml-team   definition: nvidia-com-dynamographdeployment-v1alpha1 (catalog)   age: 1h
+
+`-- service
+    |-- Frontend        2/2 ready   gpu: 2    node-01,node-02
+    |-- PrefillWorker   3/4 ready   gpu: 24   node-03,node-04,node-05
+    `-- DecodeWorker    4/4 ready   gpu: 16   node-07,node-08,node-09,node-10
+
+Phase: Running
 ```
 
 What Karta brings on top, all derived from the Karta definition:
@@ -61,7 +64,7 @@ What Karta brings on top, all derived from the Karta definition:
 - **Semantic role names** - Frontend / PrefillWorker / DecodeWorker come from the label mapping declared in the Karta YAML.
 - **Pods grouped by their role, not by their owner** - pods playing different roles are shown as separate groups even when they share the same owning resource.
 - **Normalized phase** - `Running` has the same meaning across PyTorchJob, RayCluster, Dynamo, etc.
-- **Desired vs current replicas** - `3/4 replicas` shows the scale target vs. the actual pod count, per role.
+- **Desired vs ready replicas** - `3/4 ready` shows how many pods are ready against the scale target, per role.
 - **Collapsed plumbing** - intermediate objects (DynamoComponentDeployment, LeaderWorkerSet) are optionally hidden to reduce noise while keeping the semantic hierarchy visible.
 
 **kubectl-tree walks ownership. Karta walks semantics.**
@@ -84,21 +87,22 @@ The `ORIGIN` column in `karta definition list` shows where each definition came 
 
 ### Command structure
 
-Two top-level nouns:
+Verb-first, following the kubectl grammar (`karta VERB TYPE[/NAME]`):
 
 ```shell
-karta workload ...        # operational: what's running in my cluster
-karta definition ...      # meta: what workload types does Karta understand
+karta get <type>              # operational: what workloads of this type are running
+karta describe <type>/<name>  # operational: one workload in full
+karta definitions             # meta: what workload types does Karta understand
 ```
 
 ### Namespace behavior
 
 - Karta definitions are **cluster-scoped**. Community definitions (embedded in the binary) and cluster definitions (CRDs) both apply across all namespaces.
-- Workloads are **namespaced**. All `karta workload *` commands follow standard kubectl conventions:
+- Workloads are **namespaced**. All workload commands follow standard kubectl conventions:
   - `-n <namespace>` targets a specific namespace
   - `-A, --all-namespaces` scans all namespaces
   - Default is the namespace from the current kubeconfig context
-- `karta workload tree|status|resources <name>` operates on a single workload. The namespace is taken from `-n` or the current context. If the same name exists in multiple namespaces, the command errors and asks the user to specify `-n`.
+- `karta describe <type>/<name>` operates on a single workload. The namespace is taken from `-n` or the current context.
 - Pod discovery for tree building happens in the workload's namespace - pods outside it are not considered.
 
 ### `karta get`
@@ -126,71 +130,48 @@ The cross-type view - every workload Karta covers, in one table, which is the vi
 
 Clusters can be huge - thousands of workloads across many types is a realistic scenario for our users. `karta get` pages through large result sets so per-request API pressure stays bounded. Note that `--chunk-size` bounds neither total memory nor time-to-first-row: every page is retained, and the default ordering is global, so the whole result is sorted before the first row is rendered.
 
-### `karta workload tree <name>`
+### `karta describe <type>/<name>`
 
-Hierarchical tree view: workload -> components -> instances -> pods. Each component shows its readiness and resource usage inline, so operators can see the state of the workload at a glance without running additional commands.
-
-Simple workload (PyTorchJob):
+The full picture for one workload: the semantic tree with live pods, the normalized phase, and the per-component resource breakdown. It supersedes the separate tree, status and resources commands sketched earlier in this design - they answered three parts of one question, and a reader who ran one usually wanted the others - and pairs with `karta get` as the kubectl-style get/describe split.
 
 ```shell
-$ karta workload tree llama-finetune
-PyTorchJob/llama-finetune [Running]
-├── master   (1/1 replicas)   1/1 ready   gpu: 1    nodes: node-01
-│   └── Pod/llama-finetune-master-0    Running   gpu: 1   node-01
-└── worker   (4/4 replicas)   3/4 ready   gpu: 32   nodes: node-02,03,04
-    ├── Pod/llama-finetune-worker-0    Running   gpu: 8   node-02
-    ├── Pod/llama-finetune-worker-1    Running   gpu: 8   node-03
-    ├── Pod/llama-finetune-worker-2    Running   gpu: 8   node-04
-    └── Pod/llama-finetune-worker-3    Pending   gpu: 8   <none>
+$ karta describe pytorchjob/llama-finetune -n ml-team
+PyTorchJob/llama-finetune   namespace: ml-team   definition: kubeflow-org-pytorchjob-v1 (catalog)   age: 2h
+
+|-- master                        1/1 ready                 gpu: 1    node-01
+|   `-- llama-finetune-master-0   Running                   gpu: 1    node-01
+`-- worker                        3/4 ready                 gpu: 32   node-02,node-03,node-04
+    |-- llama-finetune-worker-0   Running                   gpu: 8    node-02
+    |-- llama-finetune-worker-1   Running                   gpu: 8    node-03
+    |-- llama-finetune-worker-2   Running                   gpu: 8    node-04
+    `-- llama-finetune-worker-3   Pending (Unschedulable)   gpu: 8    <none>
+
+Phase: Running
+
+Resources:
+COMPONENT   REPLICAS   GPU   CPU   MEMORY
+master      1          1     4     16Gi
+worker      4          32    16    64Gi
+TOTAL       5          33    20    80Gi
 ```
 
-Complex workload (Dynamo - multi-instance with nested children):
+Key flags:
+- `-n, --namespace` - target namespace, kubectl semantics
+- `-f, --file <manifest>` - describe a manifest that has not been submitted; `-` reads stdin
+- `--pod-limit <n>` - maximum pod rows per component; the default renders every pod
+- `-o <table|json|yaml>` - output format. `wide` is rejected: one workload has no extra columns to widen into
 
-```shell
-$ karta workload tree my-dynamo-graph
-DynamoGraphDeployment/my-dynamo-graph [Running]
-└── service
-    ├── Frontend        (2/2 replicas)   2/2 ready   gpu: 2    nodes: node-01,02
-    │   ├── Pod/frontend-0    Running   gpu: 1   node-01
-    │   └── Pod/frontend-1    Running   gpu: 1   node-02
-    ├── PrefillWorker   (3/4 replicas)   3/3 ready   gpu: 24   nodes: node-03..05
-    │   ├── Pod/prefill-0     Running   gpu: 8   node-03
-    │   ├── Pod/prefill-1     Running   gpu: 8   node-04
-    │   └── Pod/prefill-2     Running   gpu: 8   node-05
-    └── DecodeWorker    (4/4 replicas)   4/4 ready   gpu: 16   nodes: node-07..10
-        ├── Pod/decode-0      Running   gpu: 4   node-07
-        ├── Pod/decode-1      Running   gpu: 4   node-08
-        ├── Pod/decode-2      Running   gpu: 4   node-09
-        └── Pod/decode-3      Running   gpu: 4   node-10
-```
+Every section renders from a single `WorkloadView`, so the human output and the machine output cannot drift. `-o json` emits that view directly, without the `items`/`count` envelope the list commands carry: an envelope says nothing about a single subject and costs a consumer an `items[0]` hop. Values are typed - `replicas` is `{desired, current, ready}` numbers, never a `"3/4"` a consumer re-parses; an unscheduled pod carries a null node, not an empty string. The JSON shape is deliberately unstable until the CLI reaches v1.
 
-### `karta workload status <name>`
+By default every pod row renders, the way `kubectl-tree` renders every descendant: the hidden pod is the one a reader most needs. `--pod-limit` opts into truncation, sorting unhealthy pods first so a failing pod is never what gets cut, and reporting what it hid.
 
-Workload status as Karta sees it - normalized phases and per-component readiness.
+**Pod attribution.** A Karta `PodSelector` says which component type a pod plays, never which workload it belongs to: matching on the selector alone would claim every PyTorchJob worker in the namespace. So pods are scoped by ownership first - each candidate pod's controller owner-reference chain is walked, fetching intermediates, until it reaches the workload root - and only then placed by the definition's selectors. Intermediate fetches are cached hit and miss alike, so siblings sharing a ReplicaSet cost one read.
 
-```shell
-$ karta workload status llama-finetune
-Workload:  PyTorchJob/llama-finetune
-Phase:     Running
-Age:       2h15m
+**File mode.** `karta describe -f jobset.yaml` builds the same view from a manifest alone, resolving the definition by the manifest's GVK, with no cluster and no pods. The structure and the desired scale are real; everything live is left empty and the output says so. Useful for checking a desired topology before submitting it.
 
-Components:
-  master:  1/1 pods running
-  worker:  3/4 pods running
-```
+**Failures.** Each condition a caller can act on differently gets its own exit code: a missing workload, a type no definition covers, a usage error, and a cluster or auth failure are told apart without parsing a message. The no-definition case is emitted as a parseable object on stdout under a machine format, because an agent's fallback there - inspect the object raw, or author a definition - is unlike its fallback for any other failure.
 
-### `karta workload resources <name>`
-
-Resource breakdown for a single workload by component.
-
-```shell
-$ karta workload resources llama-finetune
-COMPONENT   REPLICAS   CPU(req)   MEM(req)   GPU
-master      1          4          16Gi       1
-worker      4          16         64Gi       32
-────────────────────────────────────────────────
-TOTAL       5          20         80Gi       33
-```
+A later phase accepts a bare `<name>` and searches across every known kind, erroring rather than guessing when more than one kind matches.
 
 ### `karta definition list` / `karta definition describe <name>` / `karta definition validate <file>`
 
@@ -287,88 +268,82 @@ The builder works top-down, component by component, reading the desired structur
 
 ### Pod matching (live consumers)
 
-Mapping live pods onto the tree is a separate step from building it. Building stays spec-only so it has no cluster dependency; a consumer that needs per-pod status (phase, node, readiness) or the per-replica breakdown fetches the pods itself and matches them onto the tree. The matching strategy is decoupled behind a `PodMatcher` so each consumer can plug in its own logic via the `pkg/resource` pod selectors (`ReplicaSelector.KeyPath`, `ComponentInstanceSelector`):
+Mapping live pods onto the tree is a separate step from building it. Building stays spec-only so it has no cluster dependency; a consumer that needs per-pod status (phase, node, readiness) or the per-replica breakdown fetches the pods itself and matches them onto the tree, using the `pkg/resource` pod selectors (`ComponentTypeSelector`, `ComponentInstanceSelector`, `ReplicaSelector.KeyPath`) through `resource.PodQuerier`.
 
-```go
-type PodMatcher interface {
-    Matches(ctx context.Context, pod *corev1.Pod, node *ComponentNode) (bool, error)
-}
-```
+It happens in two stages, because the selectors answer only one of the two questions involved. A selector says which component type a pod plays; it does not say which workload the pod belongs to, so matching on it alone would claim every PyTorchJob worker in the namespace rather than this job's. Scoping to one workload is therefore ownership, not selectors: each candidate pod's controller owner-reference chain is walked, fetching intermediate objects, until it reaches the workload root or runs out of hops.
 
-Matching walks top-down, component by component. At each component the matcher claims the pods that belong to it or its descendants, then distributes them across instances; each instance passes only its pods down to child components, narrowing the set at each level until pods reach their leaf component.
+Only then does placement run, walking top-down, component by component. At each component the matcher claims the pods that belong to it or its descendants, then distributes them across instances; each instance passes only its pods down to child components, narrowing the set at each level until pods reach their leaf component.
 
 Example for a PyTorchJob with 5 pods (master-0, worker-0..3):
 
 ```shell
-[5 pods] → master component: matcher claims master-0 → [4 remaining]
-         → worker component: matcher claims worker-0..3
+[5 pods] -> master component: matcher claims master-0 -> [4 remaining]
+         -> worker component: matcher claims worker-0..3
 ```
 
 Example for Dynamo with 6 pods (2 frontend, 4 prefill):
 
 ```shell
-[6 pods] → service component: matcher claims all 6
-           → "Frontend" instance: 2 pods
-             → lws child: matcher claims them → placed
-           → "PrefillWorker" instance: 4 pods
-             → lws child: matcher claims them → placed
+[6 pods] -> service component: matcher claims all 6
+           -> "Frontend" instance: 2 pods
+             -> lws child: matcher claims them -> placed
+           -> "PrefillWorker" instance: 4 pods
+             -> lws child: matcher claims them -> placed
 ```
 
 ### `WorkloadView` - CLI/web layer
 
-The CLI walks the `WorkloadTree` and computes display data as it traverses: resource aggregation (CPU, memory, GPU summed up the tree), ready counts ("3/4"), and pod details (phase, node). This `WorkloadView` is what gets rendered as table, tree, JSON, or served via web/MCP.
+The CLI walks the `WorkloadTree` and computes display data as it traverses: resource aggregation (CPU, memory, GPU summed up the tree), ready counts, and pod details (phase, node). This `WorkloadView` is what gets rendered as table, tree, JSON, or served via web/MCP. It is what `karta describe` emits under `-o json`, and every section of the human output is a projection of it, so the two cannot drift.
+
+Values are typed rather than pre-rendered. A `ReadyCount string` holding `"3/4"` was considered and rejected: it forces every consumer to re-parse a display string, and it breaks silently the day the rendering changes. The same reasoning gives a pod an explicit null node when it is unscheduled, rather than an empty string standing in for one.
+
+Instances do not appear as a level of their own. A component whose instances carry an instance key or a replica key renders one child component per instance, named by that key, which is the shape a reader sees in the tree and the shape a consumer walks; a single-instance component is just itself. The uniform component -> instance -> component shape stays in `WorkloadTree`, where a consumer that needs it can walk it.
 
 ```go
-type WorkloadView struct {
-    Name       string
-    Namespace  string
-    Kind       string              // "PyTorchJob", "RayCluster", etc.
-    APIVersion string
-    Age        time.Duration
-    CreatedAt  time.Time
+type DescribeView struct {
+    Name       string    `json:"name"`
+    Namespace  string    `json:"namespace"`
+    Kind       string    `json:"kind"`       // "PyTorchJob", "RayCluster", etc.
+    APIVersion string    `json:"apiVersion"`
+    CreatedAt  time.Time `json:"createdAt"`  // age is derived, never serialized
+    Definition string    `json:"definition"` // the Karta that resolved it
+    Origin     string    `json:"origin"`     // catalog | cluster
+    Phases     []string  `json:"phases"`     // from WorkloadTree.Status.Phases
+    FileMode   bool      `json:"fileMode"`   // built from a manifest, no live data
 
-    Phases     []string            // from WorkloadTree.Status.Phases
-    Resources  ResourceSummary     // aggregated across all components (computed)
-    Children   []ComponentView
+    Resources  Resources       `json:"resources"`  // summed across components
+    Components []ComponentView `json:"components"`
 }
 
 type ComponentView struct {
-    Name       string
-    Kind       string
-    Instances  []InstanceView
-    Scale      ScaleView
-    Resources  ResourceSummary     // aggregated across instances (computed)
-    ReadyCount string              // "3/4" (computed from live pods)
-    Nodes      []string            // distinct nodes hosting this component's pods (computed)
+    Name      string          `json:"name"`           // instance key when multi-instance
+    Kind      string          `json:"kind,omitempty"` // empty for a grouping component
+    Replicas  Replicas        `json:"replicas"`
+    Resources Resources       `json:"resources"`      // request times desired scale
+    Nodes     []string        `json:"nodes,omitempty"`
+    Pods      []PodView       `json:"pods,omitempty"`
+    Children  []ComponentView `json:"children,omitempty"`
 }
 
-type ScaleView struct {
-    Replicas    int32
-    MinReplicas *int32
-    MaxReplicas *int32
-}
-
-type InstanceView struct {
-    InstanceKey *string             // nil = single instance
-    ReplicaKey  *string
-    Resources   ResourceSummary    // from extracted pod spec (computed)
-    Pods        []PodView
-    Children    []ComponentView    // child components under this instance
+type Replicas struct {
+    Desired int32 `json:"desired"` // from the spec
+    Current int32 `json:"current"` // pods attributed to this component
+    Ready   int32 `json:"ready"`
 }
 
 type PodView struct {
-    Name       string
-    Phase      string              // Running, Pending, Succeeded, Failed
-    Ready      bool
-    Node       string
-    Resources  ResourceSummary     // from live pod spec (computed)
+    Name      string    `json:"name"`
+    Phase     string    `json:"phase"`  // Running, Pending, Succeeded, Failed
+    Ready     bool      `json:"ready"`
+    Node      *string   `json:"node"`             // null when unscheduled
+    Reason    string    `json:"reason,omitempty"` // why it is not running
+    Resources Resources `json:"resources"`
 }
 
-type ResourceSummary struct {
-    CPUMillis    int64
-    MemoryBytes  int64
-    GPUs         int64
-    Extended     map[string]int64
+type Resources struct {
+    GPUs        int64 `json:"gpus"`
+    CPUMillis   int64 `json:"cpuMillis"`
+    MemoryBytes int64 `json:"memoryBytes"`
 }
 ```
 


### PR DESCRIPTION
## What does this PR do?

Replaces the workload tree, status and resources sketches with describe, and brings the design document in line with what shipped: verb-first grammar, two-stage pod matching, and the WorkloadView struct describe emits.

Part of a seven-PR stack implementing `kli describe` (#206). Targets `feat/cli-describe-file-mode`, which must merge first.

## Related issue(s)

Refs #206

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
