### PR TITLE
fix(catalog): tolerate missing worker groups in Ray kartas

### DIFF
--- a/docs/catalog/ray-io-raycluster-v1.yaml
+++ b/docs/catalog/ray-io-raycluster-v1.yaml
@@ -53,12 +53,12 @@ spec:
           kind: Pod
         ownerRef: raycluster
         specDefinition:
-          podTemplateSpecPath: .spec.workerGroupSpecs[].template
+          podTemplateSpecPath: .spec.workerGroupSpecs[]?.template
         scaleDefinition:
-          replicasPath: .spec.workerGroupSpecs[].replicas
-          minReplicasPath: .spec.workerGroupSpecs[].minReplicas
-          maxReplicasPath: .spec.workerGroupSpecs[].maxReplicas
-        instanceIdPath: .spec.workerGroupSpecs[].groupName
+          replicasPath: .spec.workerGroupSpecs[]?.replicas
+          minReplicasPath: .spec.workerGroupSpecs[]?.minReplicas
+          maxReplicasPath: .spec.workerGroupSpecs[]?.maxReplicas
+        instanceIdPath: .spec.workerGroupSpecs[]?.groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]

--- a/docs/catalog/ray-io-rayjob-v1.yaml
+++ b/docs/catalog/ray-io-rayjob-v1.yaml
@@ -62,12 +62,12 @@ spec:
           kind: Pod
         ownerRef: rayjob
         specDefinition:
-          podTemplateSpecPath: .spec.rayClusterSpec.workerGroupSpecs[].template
+          podTemplateSpecPath: .spec.rayClusterSpec.workerGroupSpecs[]?.template
         scaleDefinition:
-          replicasPath: .spec.rayClusterSpec.workerGroupSpecs[].replicas // 1
-          minReplicasPath: .spec.rayClusterSpec.workerGroupSpecs[].minReplicas
-          maxReplicasPath: .spec.rayClusterSpec.workerGroupSpecs[].maxReplicas
-        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[].groupName
+          replicasPath: .spec.rayClusterSpec.workerGroupSpecs[]? | (.replicas // 1)
+          minReplicasPath: .spec.rayClusterSpec.workerGroupSpecs[]?.minReplicas
+          maxReplicasPath: .spec.rayClusterSpec.workerGroupSpecs[]?.maxReplicas
+        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[]?.groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]

--- a/docs/catalog/ray-io-rayservice-v1.yaml
+++ b/docs/catalog/ray-io-rayservice-v1.yaml
@@ -65,10 +65,10 @@ spec:
           kind: Pod
         ownerRef: rayservice
         specDefinition:
-          podTemplateSpecPath: .spec.rayClusterConfig.workerGroupSpecs[].template
+          podTemplateSpecPath: .spec.rayClusterConfig.workerGroupSpecs[]?.template
         scaleDefinition:
-          replicasPath: .spec.rayClusterConfig.workerGroupSpecs[].replicas // 1
-        instanceIdPath: .spec.rayClusterConfig.workerGroupSpecs[].groupName
+          replicasPath: .spec.rayClusterConfig.workerGroupSpecs[]? | (.replicas // 1)
+        instanceIdPath: .spec.rayClusterConfig.workerGroupSpecs[]?.groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -4,6 +4,7 @@
 package catalog
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,11 +12,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
 
 	v1alpha1 "github.com/run-ai/karta/pkg/api/runai/v1alpha1"
 	"github.com/run-ai/karta/pkg/catalog/kartas"
+	"github.com/run-ai/karta/pkg/resource"
 )
 
 // catalogDir returns the docs/catalog directory relative to this test file.
@@ -167,4 +170,69 @@ var _ = Describe("catalog files", func() {
 			Expect(v1alpha1.NewKartaValidator(&k).Validate()).To(Succeed(), path)
 		}
 	})
+})
+
+// Worker groups are optional in every Ray kind, so extraction over the worker
+// component must yield zero instances for a manifest without them instead of
+// failing on iterating a missing array.
+var _ = Describe("Ray kartas", func() {
+	type rayCase struct {
+		kind        string
+		clusterSpec []string
+	}
+	cases := []rayCase{
+		{kind: "RayJob", clusterSpec: []string{"spec", "rayClusterSpec"}},
+		{kind: "RayCluster", clusterSpec: []string{"spec"}},
+		{kind: "RayService", clusterSpec: []string{"spec", "rayClusterConfig"}},
+	}
+
+	extractWorkerInstances := func(kind string, obj *unstructured.Unstructured) (map[string]resource.ExtractedInstance, error) {
+		k, err := Get(schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: kind})
+		Expect(err).NotTo(HaveOccurred())
+		worker, err := resource.NewComponentFactoryFromObject(k, obj).GetComponent("worker")
+		Expect(err).NotTo(HaveOccurred())
+		return worker.GetExtractedInstances(context.Background())
+	}
+
+	newManifest := func(c rayCase, workerGroups any) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "ray.io/v1",
+			"kind":       c.kind,
+			"metadata":   map[string]any{"name": "test", "namespace": "default"},
+			"spec":       map[string]any{},
+		}}
+		head := map[string]any{"template": map[string]any{"spec": map[string]any{}}}
+		Expect(unstructured.SetNestedField(obj.Object, head, append(c.clusterSpec, "headGroupSpec")...)).To(Succeed())
+		if workerGroups != nil {
+			Expect(unstructured.SetNestedField(obj.Object, workerGroups, append(c.clusterSpec, "workerGroupSpecs")...)).To(Succeed())
+		}
+		return obj
+	}
+
+	for _, c := range cases {
+		It("extracts zero worker instances when "+c.kind+" has no worker groups", func() {
+			instances, err := extractWorkerInstances(c.kind, newManifest(c, nil))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(instances).To(BeEmpty())
+		})
+
+		It("extracts zero worker instances when "+c.kind+" worker groups are empty", func() {
+			instances, err := extractWorkerInstances(c.kind, newManifest(c, []any{}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(instances).To(BeEmpty())
+		})
+
+		It("extracts worker instances by group name for "+c.kind, func() {
+			group := map[string]any{
+				"groupName": "gpu-worker",
+				"replicas":  int64(2),
+				"template":  map[string]any{"spec": map[string]any{}},
+			}
+			instances, err := extractWorkerInstances(c.kind, newManifest(c, []any{group}))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(instances).To(HaveKey("gpu-worker"))
+			Expect(instances["gpu-worker"].Scale).NotTo(BeNil())
+			Expect(*instances["gpu-worker"].Scale.Replicas).To(Equal(int32(2)))
+		})
+	}
 })

--- a/pkg/catalog/kartas/raycluster.go
+++ b/pkg/catalog/kartas/raycluster.go
@@ -62,14 +62,14 @@ func Raycluster() *v1alpha1.Karta {
 						Kind:     &v1alpha1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 						OwnerRef: ptr.To("raycluster"),
 						SpecDefinition: &v1alpha1.SpecDefinition{
-							PodTemplateSpecPath: ptr.To(".spec.workerGroupSpecs[].template"),
+							PodTemplateSpecPath: ptr.To(".spec.workerGroupSpecs[]?.template"),
 						},
 						ScaleDefinition: &v1alpha1.ScaleDefinition{
-							ReplicasPath:    ptr.To(".spec.workerGroupSpecs[].replicas"),
-							MinReplicasPath: ptr.To(".spec.workerGroupSpecs[].minReplicas"),
-							MaxReplicasPath: ptr.To(".spec.workerGroupSpecs[].maxReplicas"),
+							ReplicasPath:    ptr.To(".spec.workerGroupSpecs[]?.replicas"),
+							MinReplicasPath: ptr.To(".spec.workerGroupSpecs[]?.minReplicas"),
+							MaxReplicasPath: ptr.To(".spec.workerGroupSpecs[]?.maxReplicas"),
 						},
-						InstanceIdPath: ptr.To(".spec.workerGroupSpecs[].groupName"),
+						InstanceIdPath: ptr.To(".spec.workerGroupSpecs[]?.groupName"),
 						PodSelector: &v1alpha1.PodSelector{
 							ComponentTypeSelector: &v1alpha1.ComponentTypeSelector{
 								KeyPath: `.metadata.labels["ray.io/node-type"]`,

--- a/pkg/catalog/kartas/rayjob.go
+++ b/pkg/catalog/kartas/rayjob.go
@@ -70,14 +70,14 @@ func Rayjob() *v1alpha1.Karta {
 						Kind:     &v1alpha1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 						OwnerRef: ptr.To("rayjob"),
 						SpecDefinition: &v1alpha1.SpecDefinition{
-							PodTemplateSpecPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[].template"),
+							PodTemplateSpecPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[]?.template"),
 						},
 						ScaleDefinition: &v1alpha1.ScaleDefinition{
-							ReplicasPath:    ptr.To(".spec.rayClusterSpec.workerGroupSpecs[].replicas // 1"),
-							MinReplicasPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[].minReplicas"),
-							MaxReplicasPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[].maxReplicas"),
+							ReplicasPath:    ptr.To(".spec.rayClusterSpec.workerGroupSpecs[]? | (.replicas // 1)"),
+							MinReplicasPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[]?.minReplicas"),
+							MaxReplicasPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[]?.maxReplicas"),
 						},
-						InstanceIdPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[].groupName"),
+						InstanceIdPath: ptr.To(".spec.rayClusterSpec.workerGroupSpecs[]?.groupName"),
 						PodSelector: &v1alpha1.PodSelector{
 							ComponentTypeSelector: &v1alpha1.ComponentTypeSelector{
 								KeyPath: `.metadata.labels["ray.io/node-type"]`,

--- a/pkg/catalog/kartas/rayservice.go
+++ b/pkg/catalog/kartas/rayservice.go
@@ -63,12 +63,12 @@ func RayService() *v1alpha1.Karta {
 						Kind:     &v1alpha1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
 						OwnerRef: ptr.To("rayservice"),
 						SpecDefinition: &v1alpha1.SpecDefinition{
-							PodTemplateSpecPath: ptr.To(".spec.rayClusterConfig.workerGroupSpecs[].template"),
+							PodTemplateSpecPath: ptr.To(".spec.rayClusterConfig.workerGroupSpecs[]?.template"),
 						},
 						ScaleDefinition: &v1alpha1.ScaleDefinition{
-							ReplicasPath: ptr.To(".spec.rayClusterConfig.workerGroupSpecs[].replicas // 1"),
+							ReplicasPath: ptr.To(".spec.rayClusterConfig.workerGroupSpecs[]? | (.replicas // 1)"),
 						},
-						InstanceIdPath: ptr.To(".spec.rayClusterConfig.workerGroupSpecs[].groupName"),
+						InstanceIdPath: ptr.To(".spec.rayClusterConfig.workerGroupSpecs[]?.groupName"),
 						PodSelector: &v1alpha1.PodSelector{
 							ComponentTypeSelector: &v1alpha1.ComponentTypeSelector{
 								KeyPath: `.metadata.labels["ray.io/node-type"]`,


### PR DESCRIPTION
## What does this PR do?

worker groups are optional in RayJob , RayCluster and RayService , but the worker paths in their kartas iterate workerGroupSpecs[] unconditionally. a manifest without worker groups fails extraction with `cannot iterate over: null` , and an empty list trips the instance zip because `// 1` yields a value even for an empty iteration.

the worker paths now iterate with `[]?` , and the replicas default moves inside the iteration ( `[]? | (.replicas // 1)` ) so it applies per group. no worker groups -> zero worker instances.

`[]?` is only on the arrays the ray CRDs declare optional - required paths still fail loudly on typos.

catalog yaml regenerated with `make generate-samples`. tests cover absent , empty and populated worker groups for all three kinds.

## Related issue(s)

Fixes #356

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included