### PR TITLE
fix(samples): tolerate missing worker groups in Ray kartas (v0.2)

### DIFF
--- a/docs/samples/raycluster.yaml
+++ b/docs/samples/raycluster.yaml
@@ -51,12 +51,12 @@ spec:
           kind: Pod
         ownerRef: raycluster
         specDefinition:
-          podTemplateSpecPath: .spec.workerGroupSpecs[].template
+          podTemplateSpecPath: .spec.workerGroupSpecs[]?.template
         scaleDefinition:
-          replicasPath: .spec.workerGroupSpecs[].replicas
-          minReplicasPath: .spec.workerGroupSpecs[].minReplicas
-          maxReplicasPath: .spec.workerGroupSpecs[].maxReplicas
-        instanceIdPath: .spec.workerGroupSpecs[].groupName
+          replicasPath: .spec.workerGroupSpecs[]?.replicas
+          minReplicasPath: .spec.workerGroupSpecs[]?.minReplicas
+          maxReplicasPath: .spec.workerGroupSpecs[]?.maxReplicas
+        instanceIdPath: .spec.workerGroupSpecs[]?.groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]

--- a/docs/samples/rayjob.yaml
+++ b/docs/samples/rayjob.yaml
@@ -61,10 +61,10 @@ spec:
           kind: Pod
         ownerRef: rayjob
         specDefinition:
-          podTemplateSpecPath: .spec.rayClusterSpec.workerGroupSpecs[].template
+          podTemplateSpecPath: .spec.rayClusterSpec.workerGroupSpecs[]?.template
         scaleDefinition:
-          replicasPath: .spec.rayClusterSpec.workerGroupSpecs[].replicas // 1
-        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[].groupName
+          replicasPath: .spec.rayClusterSpec.workerGroupSpecs[]? | (.replicas // 1)
+        instanceIdPath: .spec.rayClusterSpec.workerGroupSpecs[]?.groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]

--- a/docs/samples/rayservice.yaml
+++ b/docs/samples/rayservice.yaml
@@ -63,10 +63,10 @@ spec:
           kind: Pod
         ownerRef: rayservice
         specDefinition:
-          podTemplateSpecPath: .spec.rayClusterConfig.workerGroupSpecs[].template
+          podTemplateSpecPath: .spec.rayClusterConfig.workerGroupSpecs[]?.template
         scaleDefinition:
-          replicasPath: .spec.rayClusterConfig.workerGroupSpecs[].replicas // 1
-        instanceIdPath: .spec.rayClusterConfig.workerGroupSpecs[].groupName
+          replicasPath: .spec.rayClusterConfig.workerGroupSpecs[]? | (.replicas // 1)
+        instanceIdPath: .spec.rayClusterConfig.workerGroupSpecs[]?.groupName
         podSelector:
           componentTypeSelector:
             keyPath: .metadata.labels["ray.io/node-type"]


### PR DESCRIPTION
## What does this PR do?

Backport of the Ray worker-groups hardening to the v0.2 line. On this branch the Ray definitions live as hand-written samples under `docs/samples/` (the generated catalog does not exist here), so the change is applied to the three sample files directly.

Worker groups are optional in RayJob, RayCluster, and RayService, but the worker component iterated `workerGroupSpecs[]` unconditionally: a manifest without worker groups failed instance extraction with `cannot iterate over: null`, and an empty `workerGroupSpecs` list tripped the instance zip because the trailing `// 1` yields a value even for an empty iteration.

The worker paths now iterate with `[]?` and the replicas default moves inside the iteration (`[]? | (.replicas // 1)`) so it applies per group. Same change as #357 on main.

Verified with the v0.2 engine directly: the patched rayjob sample extracts the worker instance from a real manifest, and returns zero instances (instead of erroring) for both empty and absent worker groups. All 53 recorded e2e states (rayjob + raycluster) extract clean. `make check` green.

## Related issue(s)

Fixes #356

## Checklist

- [x] All commits are signed off with DCO (`git commit -s`)
- [x] New/modified files have SPDX license and copyright headers
- [x] Documentation updated (if applicable)
- [x] Tests pass (`make check`)
- [x] No proprietary or internal information included